### PR TITLE
Allow running acceptance tests from vscode

### DIFF
--- a/jest.acceptance.config.js
+++ b/jest.acceptance.config.js
@@ -2,10 +2,8 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
-const jestConfigBase = require('./jest.config');
-
 module.exports = {
-    ...jestConfigBase,
+    ...require('./jest.base.config'),
     displayName: 'acceptance',
     maxConcurrency: 1,
     testTimeout: 30000,

--- a/jest.base.config.js
+++ b/jest.base.config.js
@@ -1,0 +1,15 @@
+// @flow
+/* eslint-disable filenames/match-regex */
+
+const config /* : any */ = {
+    // Automatically restore mock state between every test
+    restoreMocks: true,
+    collectCoverageFrom: [
+        '**/src/**/*.js',
+        '!**/node_modules/**',
+        '!**/__*__/**', // ignore tests, acceptance, stories, etc
+    ],
+    coverageReporters: ['json-summary', 'lcov'],
+};
+
+module.exports = config;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,27 +1,6 @@
 // @flow
 /* eslint-disable filenames/match-regex */
-
-const config /* : any */ = {
-    // Automatically restore mock state between every test
-    restoreMocks: true,
-
-    testMatch: ['**/__tests__/*-test.js'],
-    collectCoverageFrom: [
-        '**/src/**/*.js',
-        '!**/node_modules/**',
-        '!**/__*__/**', // ignore tests, acceptance, stories, etc
-    ],
-
-    coverageReporters: ['json-summary', 'lcov'],
-
-    testURL: 'http://test.tuenti.com',
-
-    // transform: {
-    //     '^.+\\.js$': require.resolve('./src/babel-jest-transformer'),
-    // },
-
-    // A list of paths to modules that run some code to configure or set up the testing framework before each test
-    setupFilesAfterEnv: [require.resolve('./setup-test-env'), '@testing-library/jest-dom/extend-expect'],
+module.exports = {
+    ...require('./jest.base.config'),
+    projects: ['<rootDir>/jest.unit.config.js', '<rootDir>/jest.acceptance.config.js'],
 };
-
-module.exports = config;

--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -1,0 +1,12 @@
+// @flow
+/* eslint-disable filenames/match-regex */
+
+const config /* : any */ = {
+    ...require('./jest.base.config'),
+    displayName: 'unit',
+    testMatch: ['**/__tests__/*-test.js'],
+    testURL: 'http://test.tuenti.com',
+    setupFilesAfterEnv: [require.resolve('./setup-test-env'), '@testing-library/jest-dom/extend-expect'],
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
         "css/*"
     ],
     "scripts": {
-        "test": "jest",
+        "test": "jest --config jest.unit.config.js",
+        "test-acceptance": "cross-env SCREENSHOT=1 HEADLESS=1 yarn test-acceptance-ui",
+        "test-acceptance-ui": "jest --config jest.acceptance.config.js",
         "prettier-check": "prettier --check '**/*.js' '**/*.json'",
         "lint": "eslint --report-unused-disable-directives .",
         "prebuild": "yarn clean",
@@ -22,8 +24,6 @@
         "playroom": "playroom start",
         "now-build": "yarn storybook-static && ./node_modules/.bin/playroom build",
         "storybook-static": "rimraf public && yarn build-storybook -o public --quiet",
-        "test-acceptance": "cross-env SCREENSHOT=1 HEADLESS=1 yarn test-acceptance-ui",
-        "test-acceptance-ui": "jest --config jest.acceptance.config.js",
         "up-chromium": "docker-compose up -d chromium"
     },
     "browserslist": [


### PR DESCRIPTION
vscode extension uses the root `jest.config.js` file, so that file should support acceptance tests too, not only units. This PR creates two different jest projects (unit and acceptance) and a root `jest.config.js` file that groups both projects.