### PR TITLE
Fix for DOM access before document ready

### DIFF
--- a/src/portal.tsx
+++ b/src/portal.tsx
@@ -16,37 +16,34 @@ type Props = {
 };
 
 const Portal: React.FC<Props> = ({children, className}) => {
-    const rootElemRef: React.MutableRefObject<HTMLElement> = React.useRef(null as any);
-    const isDOM = typeof document !== 'undefined';
-
-    if (rootElemRef.current === null && isDOM) {
-        rootElemRef.current = document.createElement('div');
-    }
+    const [container, setContainer] = React.useState<HTMLDivElement | null>(null);
 
     React.useEffect(() => {
-        const modalRoot = document.body;
-
-        modalRoot.appendChild(rootElemRef.current);
-
-        return () => {
-            modalRoot.removeChild(rootElemRef.current);
-        };
-    }, []);
-
-    React.useEffect(() => {
-        const divContainer = rootElemRef.current;
-
-        if (className) {
-            divContainer.classList.add(className);
+        if (!container) {
+            const newContainer = document.createElement('div');
+            setContainer(newContainer);
+            document.body.appendChild(newContainer);
         }
 
         return () => {
-            if (className) {
-                divContainer.classList.remove(className);
+            if (container) {
+                document.body.removeChild(container);
             }
         };
-    }, [className]);
+    }, [container]);
 
-    return isDOM ? ReactDOM.createPortal(children, rootElemRef.current) : null;
+    React.useEffect(() => {
+        if (container && className) {
+            container.classList.add(className);
+        }
+
+        return () => {
+            if (container && className) {
+                container.classList.remove(className);
+            }
+        };
+    }, [className, container]);
+
+    return container && ReactDOM.createPortal(children, container);
 };
 export default Portal;


### PR DESCRIPTION
I know this has been discussed previously as a WONTFIX, since good practices mandate that we load JS code at the bottom of the body element. However:

* We currently don't have control over this in the CMS frontend.
* Fixing it is going to be relatively costly (specially compared to the line count in this PR!)
* We totally want to fix it properly :crossed_fingers:, we just don't want to be blocked on new features while the work to fix it is ongoing.
* I don't think there are significant downsides to this approach.
  * In particular, I don't think this will encourage people to load JS in the non-recommended way. 
* And, personally, I would argue that a library should make as few assumptions as possible about how it is loaded :fire: 