### PR TITLE
Update snippets.tsx

### DIFF
--- a/playroom/snippets.tsx
+++ b/playroom/snippets.tsx
@@ -347,9 +347,9 @@ const tabsSnippets = [
             selectedIndex={getState('tabIndex')}
             onChange={setState('tabIndex')}
             tabs={[
-                {text: 'Tab 1', icon: <IconAppointmentFilled />},
-                {text: 'Tab 2', icon: <IconBrainFilled />},
-                {text: 'Tab 3', icon: <IconBusFilled />},
+                {text: 'Tab 1', icon: <IconAppointmentRegular />},
+                {text: 'Tab 2', icon: <IconBrainRegular />},
+                {text: 'Tab 3', icon: <IconBusRegular />},
             ]}
         />`,
     },


### PR DESCRIPTION
I changed icons weight in tab snippet. From filled to regular.

Icon filled only is used for TV apps or devices with low resolution
Icon light for icon equal or bigger than 64px
Icon regular for the rest of icons