### PR TITLE
feat(Form): new onValidationErrors listener

### DIFF
--- a/flow-defs/form.js.flow
+++ b/flow-defs/form.js.flow
@@ -1,26 +1,15 @@
 // @flow
 
 import * as React from "react";
+import type { FormErrors } from "./form-context";
 declare type FormValues = { [name: string]: any, ... };
-/**
- * This TrackingEvent is not like the one in utils/types, because here the action attribute is optional and
- * it has a default value of 'inline_error'
- */
-declare type TrackingEvent = {
-  [key: string]: mixed,
-  +category: string,
-  +action?: string,
-  +label?: string,
-  +value?: number,
-  ...
-};
 declare type FormProps = {
   id?: string,
   onSubmit: (values: FormValues, rawValues: FormValues) => Promise<void> | void,
   initialValues?: FormValues,
   autoJump?: boolean,
   children: React.Node,
-  errorTrackingEvent?: TrackingEvent,
+  onValidationErrors?: (errors: FormErrors) => void,
   className?: string,
 };
 declare var Form: React.ComponentType<FormProps>;

--- a/size-stats.json
+++ b/size-stats.json
@@ -1,11 +1,11 @@
 {
     "dist": {
-        "js": 5054425,
-        "jsNoMisticaIcons": 652939
+        "js": 5054045,
+        "jsNoMisticaIcons": 652559
     },
     "distEs": {
-        "js": 3014829,
-        "jsNoMisticaIcons": 489764
+        "js": 3014449,
+        "jsNoMisticaIcons": 489384
     },
     "libOverhead": {
         "initial": 130857,

--- a/src/__stories__/custom-validation-errors-handler-form-story.tsx
+++ b/src/__stories__/custom-validation-errors-handler-form-story.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Stack, Touchable, Form, TextField, useForm, ButtonPrimary} from '..';
+import {Stack, Touchable, Form, TextField, useForm, ButtonPrimary, Text7} from '..';
 
 export default {
     title: 'Components/Forms/Form examples',
@@ -19,9 +19,7 @@ const Card: React.FC<CardProps> = ({show, children, onPress}) => {
 };
 
 const Cards: React.FC<any> = ({activeCard, setActiveCard}) => {
-    const {validate, submit, formErrors, formStatus} = useForm();
-
-    const getCardIndexByFieldName = (name: string) => Number(name.split('-')[0]);
+    const {formErrors} = useForm();
 
     return (
         <Stack space={16}>
@@ -36,29 +34,14 @@ const Cards: React.FC<any> = ({activeCard, setActiveCard}) => {
             <Card show={activeCard === 2} onPress={() => setActiveCard(2)}>
                 <TextField name="2-baz" label="baz" />
             </Card>
-            <ButtonPrimary
-                onPress={() => {
-                    const errors = validate();
-
-                    const fieldNamesWithErrors = Object.keys(errors);
-                    if (fieldNamesWithErrors.length > 0) {
-                        // open first card containing a field with error
-                        setActiveCard(getCardIndexByFieldName(fieldNamesWithErrors[0]));
-                    } else {
-                        submit();
-                    }
-                }}
-                showSpinner={formStatus === 'sending'}
-            >
-                Send
-            </ButtonPrimary>
+            <ButtonPrimary submit>Send</ButtonPrimary>
 
             <pre>ERRORS: {JSON.stringify(formErrors, null, 2)}</pre>
         </Stack>
     );
 };
 
-export const ManualValidationAndSubmit: StoryComponent = () => {
+export const CustomValidationErrorsHandler: StoryComponent = () => {
     const [activeCard, setActiveCard] = React.useState(0);
     const [formData, setFormData] = React.useState<any>({});
 
@@ -72,29 +55,24 @@ export const ManualValidationAndSubmit: StoryComponent = () => {
             }, 1000)
         );
 
-    return (
-        <>
-            <p>This story shows a Form with manual validation and submit</p>
-            <style>{'ul, li{padding-bottom: 8px}'}</style>
-            <ul>
-                <li>
-                    Instead of a <code>Button</code> with <code>submit</code> prop, the form uses a regular{' '}
-                    <code>Button</code> with an <code>onPress</code> handler where the Form is validated and
-                    submitted
-                </li>
-                <li>
-                    See <code>onPress</code> handler of <code>Send</code> Button
-                </li>
-                <li>
-                    <code>formStatus</code> is used to set the spinner
-                </li>
-            </ul>
+    const getCardIndexByFieldName = (name: string) => Number(name.split('-')[0]);
 
-            <Form initialValues={formData} onSubmit={handleSubmit}>
+    return (
+        <Stack space={16}>
+            <Text7 regular>This story shows a Form with a custom handler for validation errors</Text7>
+
+            <Form
+                onValidationErrors={(errors) => {
+                    const firstErrorFieldName = Object.keys(errors)[0];
+                    setActiveCard(getCardIndexByFieldName(firstErrorFieldName));
+                }}
+                initialValues={formData}
+                onSubmit={handleSubmit}
+            >
                 <Cards activeCard={activeCard} setActiveCard={setActiveCard} />
             </Form>
 
             <pre>DATA: {JSON.stringify(formData, null, 2)}</pre>
-        </>
+        </Stack>
     );
 };

--- a/src/__tests__/form-test.tsx
+++ b/src/__tests__/form-test.tsx
@@ -204,12 +204,12 @@ test("if a Field is disabled we skip its validation and don't submit its value",
     expect(validate).not.toHaveBeenCalled();
 });
 
-test('can track form validation errors', async () => {
-    const logEventSpy = jest.fn();
+test('can listen to form validation errors', async () => {
+    const onValidationErrorsSpy = jest.fn();
 
     render(
-        <ThemeContextProvider theme={makeTheme({analytics: {logEvent: logEventSpy}})}>
-            <Form errorTrackingEvent={{category: 'form'}} onSubmit={() => {}}>
+        <ThemeContextProvider theme={makeTheme()}>
+            <Form onValidationErrors={onValidationErrorsSpy} onSubmit={() => {}}>
                 <TextField name="name" label="Name" />
                 <TextField name="surname" label="Surname" />
                 <EmailField name="email" label="Email" />
@@ -222,13 +222,8 @@ test('can track form validation errors', async () => {
     await userEvent.type(screen.getByLabelText('Email'), 'invalidemail');
     userEvent.click(screen.getByText('Submit'));
 
-    await waitFor(() => {
-        expect(logEventSpy).toHaveBeenCalledTimes(2);
-        expect(logEventSpy).toHaveBeenCalledWith({action: 'inline_error', category: 'form', label: 'email'});
-        expect(logEventSpy).toHaveBeenCalledWith({
-            action: 'inline_error',
-            category: 'form',
-            label: 'surname',
-        });
+    expect(onValidationErrorsSpy).toHaveBeenCalledWith({
+        email: 'Email incorrecto',
+        surname: 'Este campo es obligatorio',
     });
 });


### PR DESCRIPTION
I think this can be also done using a similar strategy to [this story](https://mistica-web.now.sh/?path=/story/components-forms-form-examples--manual-validation-and-submit):

- Remove the submit button and use an onPress button instead
- In the onPress handler call `validate()` and `submit()` functions from the flow context
- Track events if `validate()` returns errors

The disadvantages of that strategy are:

- You need to split the component in two to read the context (which is provided by Form)
- You lose the submit on enter behavior because you are not using a submit button
- More complex