### PR TITLE
WEB-69 yarn package cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
               id: yarn-cache
               with:
                   path: ./node_modules
-                  key: node_modules-${{ hashFiles('./yarn.lock') }}
+                  key: node_modules-${{ hashFiles('**/yarn.lock') }}
             - name: Install dependencies
               # skip yarn install if restored from cache
               # note that the id (yarn-cache) must match the id from actions/cache@v2 step

--- a/.github/workflows/deploy-pull-requests.yml
+++ b/.github/workflows/deploy-pull-requests.yml
@@ -21,7 +21,7 @@ jobs:
               id: yarn-cache
               with:
                   path: ./node_modules
-                  key: node_modules-${{ hashFiles('./yarn.lock') }}
+                  key: node_modules-${{ hashFiles('**/yarn.lock') }}
             - name: Install dependencies
               # skip yarn install if restored from cache
               # note that the id (yarn-cache) must match the id from actions/cache@v2 step

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
               id: yarn-cache
               with:
                   path: ./node_modules
-                  key: node_modules-${{ hashFiles('./yarn.lock') }}
+                  key: node_modules-${{ hashFiles('**/yarn.lock') }}
             - name: Install dependencies
               # skip yarn install if restored from cache
               # note that the id (yarn-cache) must match the id from actions/cache@v2 step


### PR DESCRIPTION
### Initial state:
![image](https://user-images.githubusercontent.com/579417/108349008-c402d680-71e2-11eb-8421-342e69f4a4b5.png)

---

### Using cache (as documented in cache action):
![image](https://user-images.githubusercontent.com/579417/108701045-beb9ca80-7507-11eb-9833-85cbb5c1c733.png)
* Almost no benefit, we only save time by reading packages from disk instead of downloading them

---

### Final solution (caching node_modules)
![image](https://user-images.githubusercontent.com/579417/108737998-6b5d7180-7533-11eb-8ab9-866790f30707.png)
From ~3m to ~35s
* As you can see in the image, ~35s is the time it takes to download and unzip packages. If we dedupe packages and make node_modules size smaller, this time would be reduced. 
* I did not deduped packages in this PR because for some reason it broke the build, we should do that carefully
* For reference, webapp (with local packages cache), with a much smaller node_modules, takes more than 1m to execute yarn (and not counting the time to checkout the repo)