### PR TITLE
fix(Dialogs): Make DialogRoot work with multiple react trees

### DIFF
--- a/flow-defs/dialog.js.flow
+++ b/flow-defs/dialog.js.flow
@@ -19,6 +19,7 @@ declare type DialogRootProps = {
 declare type DialogRootState = {
   dialogProps: DialogProps | null,
   isClosing: boolean,
+  instanceNumber: number,
 };
 declare export default class DialogRoot
   mixins React.Component<DialogRootProps, DialogRootState> {

--- a/size-stats.json
+++ b/size-stats.json
@@ -1,15 +1,15 @@
 {
     "dist": {
-        "js": "4949.26 KB",
-        "jsNoMisticaIcons": "654.44 KB"
+        "js": "4949.34 KB",
+        "jsNoMisticaIcons": "654.52 KB"
     },
     "distEs": {
-        "js": "2949.01 KB",
-        "jsNoMisticaIcons": "487.90 KB"
+        "js": "2949.09 KB",
+        "jsNoMisticaIcons": "487.98 KB"
     },
     "libOverhead": {
         "initial": "127.79 KB",
-        "withMistica": "256.68 KB",
-        "difference": "128.89 KB"
+        "withMistica": "256.73 KB",
+        "difference": "128.94 KB"
     }
 }

--- a/src/dialog.tsx
+++ b/src/dialog.tsx
@@ -372,12 +372,14 @@ type DialogRootProps = {children?: React.ReactNode};
 type DialogRootState = {
     dialogProps: DialogProps | null;
     isClosing: boolean;
+    instanceNumber: number;
 };
 
 export default class DialogRoot extends React.Component<DialogRootProps, DialogRootState> {
     state: DialogRootState = {
         dialogProps: null,
         isClosing: false,
+        instanceNumber: dialogRootInstances + 1,
     };
 
     componentDidMount(): void {
@@ -457,7 +459,7 @@ export default class DialogRoot extends React.Component<DialogRootProps, DialogR
     render(): React.ReactNode {
         const {isClosing, dialogProps} = this.state;
 
-        if (!dialogProps) {
+        if (!dialogProps || this.state.instanceNumber !== 1) {
             return this.props.children || null;
         }
 


### PR DESCRIPTION
Can be verified here:
https://build-pladaria.vercel.app/?path=/story/account-flows-invoicepayment--default
Related task: https://jira.tid.es/browse/WEB-124

:warning: Ignore styles and color changes (webapp was missing some changes required for the new mistica version)