### PR TITLE
fix(TextField): reset chrome autocomplete styles

### DIFF
--- a/src/text-field-base.tsx
+++ b/src/text-field-base.tsx
@@ -217,6 +217,14 @@ const useStyles = createUseStyles((theme) => ({
         // Only apply when Firefox, otherwise it breaks styles in safari mobile
         '&[type="date"]:not(:valid):not(:focus)': isFirefox() ? {color: 'transparent'} : {},
         '&[type="datetime-local"]:not(:valid):not(:focus)': isFirefox() ? {color: 'transparent'} : {},
+
+        // Override Chrome input autocomplete styles:
+        '&:-webkit-autofill': {
+            textFillColor: theme.colors.textPrimary,
+            // The background can not be overriden, but we can delay the background color transition to avoid the change
+            transitionProperty: 'background-color',
+            transitionDelay: '99999s',
+        },
     },
     endIcon: {
         paddingLeft: 8,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1849576/114858556-e7648f00-9de9-11eb-8a22-652c527d472e.png)
After:
![image](https://user-images.githubusercontent.com/1849576/114858641-06632100-9dea-11eb-94a0-3406aa619204.png)


jira: WEB-167