### PR TITLE
fix(Text): reset textDecoration when switching back to undefined

### DIFF
--- a/flow-defs/text.js.flow
+++ b/flow-defs/text.js.flow
@@ -4,7 +4,7 @@ import * as React from "react";
 declare type FontWeight = "light" | "regular" | "medium";
 export type TextPresetProps = {|
   color?: string,
-  textDecoration?: "underline" | "line-through",
+  textDecoration?: "underline" | "line-through" | "none",
   children?: React.Node,
   truncate?: boolean | number,
   uppercase?: boolean,

--- a/size-stats.json
+++ b/size-stats.json
@@ -1,15 +1,15 @@
 {
     "dist": {
-        "js": "5401.82 KB",
-        "jsNoMisticaIcons": "755.07 KB"
+        "js": "5401.94 KB",
+        "jsNoMisticaIcons": "755.19 KB"
     },
     "distEs": {
-        "js": "3093.14 KB",
-        "jsNoMisticaIcons": "557.63 KB"
+        "js": "3093.26 KB",
+        "jsNoMisticaIcons": "557.75 KB"
     },
     "libOverhead": {
         "initial": "127.79 KB",
-        "withMistica": "264.22 KB",
-        "difference": "136.43 KB"
+        "withMistica": "264.26 KB",
+        "difference": "136.47 KB"
     }
 }

--- a/src/text.tsx
+++ b/src/text.tsx
@@ -33,7 +33,7 @@ const useStyles = createUseStyles((theme) => {
             fontWeight: ({weight}) => (weight ? mapToWeight[weight] : 'inherit'),
             color: ({isInverse, color = theme.colors.textPrimary}) =>
                 isInverse ? inverseColorsMap[color] ?? color : color,
-            textDecoration: (p) => p.textDecoration,
+            textDecoration: (p) => p.textDecoration ?? 'inherit',
             letterSpacing: ({letterSpacing}) => letterSpacing,
             overflowWrap: ({wordBreak}) => (wordBreak ? 'anywhere' : 'inherit'),
             // Needed to reset the default browser margin that adds to p, h1, h2... elements.
@@ -59,7 +59,7 @@ type FontWeight = 'light' | 'regular' | 'medium';
 
 export interface TextPresetProps {
     color?: string;
-    textDecoration?: 'underline' | 'line-through';
+    textDecoration?: 'underline' | 'line-through' | 'none';
     children?: React.ReactNode;
     truncate?: boolean | number;
     uppercase?: boolean;


### PR DESCRIPTION
jira: WEB-245 

bug:
https://mistica-web.vercel.app/playroom#?code=N4Igxg9gJgpiBcIA8BhAFjMBrARhAHgAQB2AhgLYwC8AOuBtnvnYRMeqcQObXADOMAC4BlQaUEwAFHQCWfACJsYdAJQBfAHw1ihQkgAqMfIIBMhCcfmYIAJ3Ey2VYDxFiJ0kHMXFlIFYQB%2BQjoAGxkfAFpBNBsIAFcuNBZ4QjjiWAAzcJgoTW1dXT4ISnNoCHy9AHpDYxMtYiRK9ExcAnqQABoQaJhKPgQAbRAAWQgANzkxGxAAXS6AdxkoaP74AYBGAAYTABYZtSA

fixed:
https://mistica-web-f78ukeztn-atabel.vercel.app/playroom#?code=N4Igxg9gJgpiBcIA8BhAFjMBrARhAHgAQB2AhgLYwC8AOuBtnvnYRMeqcQObXADOMAC4BlQaUEwAFHQCWfACJsYdAJQBfAHw1ihQkgAqMfIIBMhCcfmYIAJ3Ey2VYDxFiJ0kHMXFlIFYQB%2BQjoAGxkfAFpBNBsIAFcuNBZ4QjjiWAAzcJgoTW1dXT4ISnNoCHy9AHpDYxMtYiRK9ExcAnqQABoQaJhKPgQAbRAAWQgANzkxGxAAXS6AdxkoaP74AYBmEwAGGbUgA