### PR TITLE
chore(PreviewTools): Set controls theme to light

### DIFF
--- a/playroom/components.tsx
+++ b/playroom/components.tsx
@@ -12,7 +12,6 @@ import {
     Checkbox,
     ThemeContextProvider,
 } from '../src';
-import {useIsOsDarkModeEnabled} from '../src/theme-context-provider';
 import {Movistar, Vivo, O2, Telefonica} from './themes';
 import {useOverrideTheme} from './frame-component';
 
@@ -89,7 +88,7 @@ const useStyles = createUseStyles(() => ({
     },
 }));
 
-const themesMap: {[skinName in SkinName]: {themeConfig: ThemeConfig; text: string}} = {
+const themesMap: {[skinName: string]: {themeConfig: ThemeConfig; text: string}} = {
     Movistar: {
         text: 'Movistar',
         themeConfig: Movistar,

--- a/playroom/components.tsx
+++ b/playroom/components.tsx
@@ -131,10 +131,9 @@ const PreviewToolsControls: React.FC<PreviewToolsControlsProps> = ({
 }) => {
     const classes = useControlsStyles();
     const {colors} = useTheme();
-    const isOsDarkModeEnabled = useIsOsDarkModeEnabled();
     const {isMobile} = useScreenSize();
-    const systemColorScheme = isOsDarkModeEnabled ? 'dark' : 'light';
-    const alternativeColorScheme = systemColorScheme === 'dark' ? 'light' : 'dark';
+    const systemColorScheme = 'light';
+    const alternativeColorScheme = 'dark';
 
     if (isMobile) {
         return (
@@ -288,6 +287,7 @@ export const PreviewTools: React.FC<PreviewToolsProps> = ({
                 platformOverrides: {platform: os},
                 // Dont override mediaqueries for PreviewToolsControls, to avoid using Select instead of Tabs in desktop
                 enableTabFocus: false,
+                colorScheme: 'light',
             }}
         >
             <PreviewToolsControls


### PR DESCRIPTION
Controls theme was not forced to light, this fixes it.
Verified on Mac safari, using dark/light modes