### PR TITLE
WEB-271 migrate to dataAttributes

### DIFF
--- a/flow-defs/box.js.flow
+++ b/flow-defs/box.js.flow
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from "react";
+import type { DataAttributes } from "./utils/types";
 declare type PadSize =
   | 0
   | 2
@@ -30,6 +31,7 @@ declare type Props = {
   role?: string,
   "data-testid"?: string,
   "data-qsysid"?: string,
+  dataAttributes?: DataAttributes,
 };
 declare var Box: React.ComponentType<Props>;
 declare export default typeof Box;

--- a/flow-defs/box.js.flow
+++ b/flow-defs/box.js.flow
@@ -31,6 +31,10 @@ declare type Props = {
   role?: string,
   "data-testid"?: string,
   "data-qsysid"?: string,
+
+  /**
+   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid"
+   */
   dataAttributes?: DataAttributes,
 };
 declare var Box: React.ComponentType<Props>;

--- a/flow-defs/boxed.js.flow
+++ b/flow-defs/boxed.js.flow
@@ -11,7 +11,7 @@ declare type Props = {
   "data-qsysid"?: string,
 
   /**
-   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",
+   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid"
    */
   dataAttributes?: DataAttributes,
 };

--- a/flow-defs/boxed.js.flow
+++ b/flow-defs/boxed.js.flow
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from "react";
+import type { DataAttributes } from "./utils/types";
 declare type Props = {
   children: React.Node,
   isInverse?: boolean,
@@ -8,6 +9,11 @@ declare type Props = {
   role?: string,
   "data-testid"?: string,
   "data-qsysid"?: string,
+
+  /**
+   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",
+   */
+  dataAttributes?: DataAttributes,
 };
 declare export var Boxed: React.ComponentType<Props>;
 declare export {};

--- a/flow-defs/button.js.flow
+++ b/flow-defs/button.js.flow
@@ -20,7 +20,7 @@ declare type CommonProps = {|
   "data-testid"?: string,
 
   /**
-   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",
+   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid"
    */
   dataAttributes?: DataAttributes,
   "aria-controls"?: string,
@@ -65,7 +65,7 @@ declare type ButtonLinkCommonProps = {|
   "data-testid"?: string,
 
   /**
-   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",
+   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid"
    */
   dataAttributes?: DataAttributes,
   aligned?: boolean,

--- a/flow-defs/icon-button.js.flow
+++ b/flow-defs/icon-button.js.flow
@@ -19,7 +19,7 @@ declare type CommonProps = {|
   "data-testid"?: string,
 
   /**
-   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",
+   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid"
    */
   dataAttributes?: DataAttributes,
   newTab?: boolean,

--- a/flow-defs/icon-button.js.flow
+++ b/flow-defs/icon-button.js.flow
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from "react";
-import type { TrackingEvent } from "./utils/types";
+import type { DataAttributes, TrackingEvent } from "./utils/types";
 declare type CommonProps = {|
   children?: React.Node,
   className?: string,
@@ -12,7 +12,16 @@ declare type CommonProps = {|
   size?: number | string,
   style?: CssStyle,
   trackingEvent?: TrackingEvent | $ReadOnlyArray<TrackingEvent>,
+
+  /**
+   * @deprecated use dataAttributes
+   */
   "data-testid"?: string,
+
+  /**
+   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",
+   */
+  dataAttributes?: DataAttributes,
   newTab?: boolean,
 |};
 declare type HrefProps = {|

--- a/flow-defs/select.js.flow
+++ b/flow-defs/select.js.flow
@@ -9,6 +9,9 @@ export type SelectProps = {
   label: string,
   name: string,
   optional?: boolean,
+  /**
+   * @deprecated
+   */
   inputProps?: { [prop: string]: string, ... },
   validate?: (value: string | void, rawValue: string | void) => string | void,
   onChangeValue?: (value: string) => void,

--- a/flow-defs/text-field-base.js.flow
+++ b/flow-defs/text-field-base.js.flow
@@ -42,6 +42,9 @@ export type CommonFormFieldProps = {|
   name: string,
   optional?: boolean,
   maxLength?: number,
+  /**
+   * @deprecated
+   */
   inputProps?: { [prop: string]: string | number | void, ... },
   validate?: FieldValidator,
   autoComplete?: AutoComplete,

--- a/flow-defs/text-link.js.flow
+++ b/flow-defs/text-link.js.flow
@@ -9,6 +9,10 @@ declare type CommonProps = {|
   classes?: { [className: string]: string, ... },
   small?: boolean,
   trackingEvent?: TrackingEvent | $ReadOnlyArray<TrackingEvent>,
+
+  /**
+   * @deprecated use dataAttributes
+   */
   "data-testid"?: string,
 |};
 export type HrefProps = {|

--- a/flow-defs/touchable.js.flow
+++ b/flow-defs/touchable.js.flow
@@ -19,7 +19,7 @@ declare type CommonProps = {|
   "data-testid"?: string,
 
   /**
-   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",
+   * "data-" prefix is automatically added. For example, use "testid" instead of "data-testid"
    */
   dataAttributes?: DataAttributes,
   "aria-checked"?: "true" | "false" | boolean,

--- a/flow-defs/utils/dom.js.flow
+++ b/flow-defs/utils/dom.js.flow
@@ -1,5 +1,7 @@
 // @flow
 
+import type { DataAttributes } from "./types";
+
 /**
  * Returns true if provided type is supported <input> type
  */
@@ -19,3 +21,11 @@ declare export var removePassiveEventListener: (
   eventName: string,
   listener: (e: any) => void
 ) => void;
+/**
+ * Prefixes given attributes with `data-`
+ *
+ * For example: `{foo: 'bar'}` => `{data-foo: 'bar'}`
+ */
+declare export var getPrefixedDataAttributes: (
+  attrs?: DataAttributes | void
+) => DataAttributes;

--- a/size-stats.json
+++ b/size-stats.json
@@ -1,15 +1,15 @@
 {
     "dist": {
-        "js": "5418.22 KB",
-        "jsNoMisticaIcons": "768.13 KB"
+        "js": "5417.21 KB",
+        "jsNoMisticaIcons": "767.12 KB"
     },
     "distEs": {
-        "js": "3104.93 KB",
-        "jsNoMisticaIcons": "568.06 KB"
+        "js": "3103.96 KB",
+        "jsNoMisticaIcons": "567.09 KB"
     },
     "libOverhead": {
         "initial": "127.79 KB",
-        "withMistica": "265.43 KB",
-        "difference": "137.64 KB"
+        "withMistica": "265.27 KB",
+        "difference": "137.48 KB"
     }
 }

--- a/src/__tests__/form-test.tsx
+++ b/src/__tests__/form-test.tsx
@@ -89,23 +89,23 @@ test('fields are disabled during submit', async () => {
     render(
         <ThemeContextProvider theme={makeTheme()}>
             <Form onSubmit={handleSubmitSpy}>
-                <TextField inputProps={{'data-testid': 'username'}} label="Username" name="username" />
+                <TextField label="Username" name="username" />
                 <ButtonPrimary submit>Submit</ButtonPrimary>
             </Form>
         </ThemeContextProvider>
     );
 
-    await userEvent.type(screen.getByTestId('username'), 'pepito');
+    await userEvent.type(screen.getByLabelText('Username'), 'pepito');
     userEvent.click(screen.getByText('Submit'));
 
-    expect(screen.getByTestId('username')).toBeDisabled();
+    expect(screen.getByLabelText('Username')).toBeDisabled();
     expect(screen.getByRole('button')).toBeDisabled();
     expect(screen.getByText('Submit')).not.toBeVisible();
 
     resolveSubmitPromise();
 
     await waitFor(() => {
-        expect(screen.getByTestId('username')).not.toBeDisabled();
+        expect(screen.getByLabelText('Username')).not.toBeDisabled();
         expect(screen.getByText('Submit')).not.toBeDisabled();
     });
 });

--- a/src/__tests__/touchable-test.tsx
+++ b/src/__tests__/touchable-test.tsx
@@ -178,7 +178,12 @@ test('<a> element is rendered when "href" prop is passed and trackingEvent', asy
 
     render(
         <ThemeContextProvider theme={makeTheme({analytics: {logEvent: logEventSpy}})}>
-            <Touchable data-testid="touchable-events" href={href} newTab trackingEvent={trackingEvent}>
+            <Touchable
+                dataAttributes={{testid: 'touchable-events'}}
+                href={href}
+                newTab
+                trackingEvent={trackingEvent}
+            >
                 Test
             </Touchable>
         </ThemeContextProvider>
@@ -203,7 +208,7 @@ test('<a> element is rendered when "href" prop is passed and multiple trackingEv
     render(
         <ThemeContextProvider theme={makeTheme({analytics: {logEvent: logEventSpy}})}>
             <Touchable
-                data-testid="touchable-events"
+                dataAttributes={{testid: 'touchable-events'}}
                 href={href}
                 newTab
                 trackingEvent={[trackingEvent, trackingEvent]}

--- a/src/box.tsx
+++ b/src/box.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import {createUseStyles} from './jss';
 import classnames from 'classnames';
+import {getPrefixedDataAttributes} from './utils/dom';
+
+import type {DataAttributes} from './utils/types';
 
 const useStyles = createUseStyles(() => ({
     box: {
@@ -23,8 +26,11 @@ type Props = {
     children?: React.ReactNode;
     className?: string;
     role?: string;
+    // @deprecated use dataAttributes
     'data-testid'?: string;
+    // @deprecated use dataAttributes
     'data-qsysid'?: string;
+    dataAttributes?: DataAttributes;
 };
 
 const Box: React.FC<Props> = ({
@@ -39,7 +45,9 @@ const Box: React.FC<Props> = ({
     paddingLeft = paddingX,
     paddingRight = paddingX,
     role,
-    ...dataProps
+    'data-testid': dataTestId,
+    'data-qsysid': dataQsysId,
+    dataAttributes,
 }) => {
     const classes = useStyles({
         padding: `${paddingTop}px ${paddingRight}px ${paddingBottom}px ${paddingLeft}px`,
@@ -48,8 +56,9 @@ const Box: React.FC<Props> = ({
 
     return (
         <div
-            data-testid={dataProps['data-testid']}
-            data-qsysid={dataProps['data-qsysid']}
+            data-testid={dataTestId}
+            data-qsysid={dataQsysId}
+            {...getPrefixedDataAttributes(dataAttributes)}
             className={classnames(className, classes.box)}
             role={role}
         >

--- a/src/box.tsx
+++ b/src/box.tsx
@@ -30,6 +30,7 @@ type Props = {
     'data-testid'?: string;
     // @deprecated use dataAttributes
     'data-qsysid'?: string;
+    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid" */
     dataAttributes?: DataAttributes;
 };
 

--- a/src/boxed.tsx
+++ b/src/boxed.tsx
@@ -41,7 +41,7 @@ type Props = {
     'data-testid'?: string;
     // @deprecated use dataAttributes
     'data-qsysid'?: string;
-    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",  */
+    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid" */
     dataAttributes?: DataAttributes;
 };
 

--- a/src/boxed.tsx
+++ b/src/boxed.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import classNames from 'classnames';
 import {createUseStyles} from './jss';
 import {ThemeVariant, useIsInverseVariant} from './theme-variant-context';
+import {DataAttributes} from './utils/types';
+import {getPrefixedDataAttributes} from './utils/dom';
 
 type StylesProps = {
     isInverseInside: boolean;
@@ -34,8 +36,12 @@ type Props = {
     isInverse?: boolean;
     className?: string;
     role?: string;
+    // @deprecated use dataAttributes
     'data-testid'?: string;
+    // @deprecated use dataAttributes
     'data-qsysid'?: string;
+    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",  */
+    dataAttributes?: DataAttributes;
 };
 
 export const Boxed: React.FC<Props> = ({
@@ -43,13 +49,21 @@ export const Boxed: React.FC<Props> = ({
     isInverse: isInverseInside = false,
     className,
     role,
-    ...dataProps
+    'data-testid': dataTestId,
+    'data-qsysid': dataQsysId,
+    dataAttributes,
 }) => {
     const isInverseOutside = useIsInverseVariant();
     const classes = useStyles({isInverseOutside, isInverseInside} as StylesProps);
 
     return (
-        <div className={classNames(className, classes.boxed)} role={role} {...dataProps}>
+        <div
+            className={classNames(className, classes.boxed)}
+            role={role}
+            data-testid={dataTestId}
+            data-qsysid={dataQsysId}
+            {...getPrefixedDataAttributes(dataAttributes)}
+        >
             <ThemeVariant isInverse={isInverseInside}>{children}</ThemeVariant>
         </div>
     );

--- a/src/boxed.tsx
+++ b/src/boxed.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import classNames from 'classnames';
 import {createUseStyles} from './jss';
 import {ThemeVariant, useIsInverseVariant} from './theme-variant-context';
-import {DataAttributes} from './utils/types';
 import {getPrefixedDataAttributes} from './utils/dom';
+
+import type {DataAttributes} from './utils/types';
 
 type StylesProps = {
     isInverseInside: boolean;

--- a/src/button.tsx
+++ b/src/button.tsx
@@ -236,7 +236,7 @@ interface CommonProps {
     trackingEvent?: TrackingEvent | ReadonlyArray<TrackingEvent>;
     /** @deprecated use dataAttributes */
     'data-testid'?: string;
-    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",  */
+    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid" */
     dataAttributes?: DataAttributes;
     'aria-controls'?: string;
     'aria-expanded'?: 'true' | 'false';
@@ -454,7 +454,7 @@ interface ButtonLinkCommonProps {
     trackingEvent?: TrackingEvent | ReadonlyArray<TrackingEvent>;
     /** @deprecated use dataAttributes */
     'data-testid'?: string;
-    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",  */
+    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid" */
     dataAttributes?: DataAttributes;
     aligned?: boolean;
 }

--- a/src/dialog.tsx
+++ b/src/dialog.tsx
@@ -149,7 +149,7 @@ const Dialog: React.FC<DialogProps> = (props) => {
 
     const mainButtonProps = {
         onPress: handleAccept ? handleAccept : () => {},
-        'data-testid': 'dialog-accept-button',
+        dataAttributes: {testid: 'dialog-accept-button'},
         children: acceptText,
     };
 
@@ -179,7 +179,7 @@ const Dialog: React.FC<DialogProps> = (props) => {
                         <ButtonSecondary
                             tabIndex={2} // eslint-disable-line jsx-a11y/tabindex-no-positive
                             onPress={handleCancel}
-                            data-testid="dialog-cancel-button"
+                            dataAttributes={{testid: 'dialog-cancel-button'}}
                         >
                             {cancelText}
                         </ButtonSecondary>

--- a/src/icon-button.tsx
+++ b/src/icon-button.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import Touchable from './touchable';
+import {getPrefixedDataAttributes} from './utils/dom';
 
-import type {TrackingEvent} from './utils/types';
+import type {DataAttributes, TrackingEvent} from './utils/types';
 
 const ICON_SIZE_1 = 24;
 
@@ -39,7 +40,10 @@ interface CommonProps {
     size?: number | string;
     style?: React.CSSProperties;
     trackingEvent?: TrackingEvent | ReadonlyArray<TrackingEvent>;
+    /** @deprecated use dataAttributes */
     'data-testid'?: string;
+    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",  */
+    dataAttributes?: DataAttributes;
     newTab?: boolean;
 }
 
@@ -93,17 +97,13 @@ const IconButton: React.FC<Props> = (props) => {
             ...props.style,
         },
         trackingEvent: props.trackingEvent,
+        'data-testid': props['data-testid'],
+        ...getPrefixedDataAttributes(props.dataAttributes),
     };
 
     if (props.href) {
         return (
-            <Touchable
-                data-testid={props['data-testid']}
-                {...commonProps}
-                href={props.href}
-                newTab={props.newTab}
-                label={props.label}
-            >
+            <Touchable {...commonProps} href={props.href} newTab={props.newTab} label={props.label}>
                 {!icon && React.Children.only(children)}
             </Touchable>
         );
@@ -111,7 +111,6 @@ const IconButton: React.FC<Props> = (props) => {
     if (props.to) {
         return (
             <Touchable
-                data-testid={props['data-testid']}
                 {...commonProps}
                 to={props.to}
                 fullPageOnWebView={props.fullPageOnWebView}
@@ -125,19 +124,14 @@ const IconButton: React.FC<Props> = (props) => {
 
     if (props.onPress) {
         return (
-            <Touchable
-                data-testid={props['data-testid']}
-                {...commonProps}
-                onPress={props.onPress}
-                label={props.label}
-            >
+            <Touchable {...commonProps} onPress={props.onPress} label={props.label}>
                 {!icon && React.Children.only(children)}
             </Touchable>
         );
     }
 
     return (
-        <Touchable {...commonProps} maybe data-testid={props['data-testid']}>
+        <Touchable {...commonProps} maybe>
             {!icon && React.Children.only(children)}
         </Touchable>
     );

--- a/src/icon-button.tsx
+++ b/src/icon-button.tsx
@@ -42,7 +42,7 @@ interface CommonProps {
     trackingEvent?: TrackingEvent | ReadonlyArray<TrackingEvent>;
     /** @deprecated use dataAttributes */
     'data-testid'?: string;
-    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",  */
+    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid" */
     dataAttributes?: DataAttributes;
     newTab?: boolean;
 }

--- a/src/select.tsx
+++ b/src/select.tsx
@@ -106,7 +106,7 @@ export type SelectProps = {
     label: string;
     name: string;
     optional?: boolean;
-    // use `inputProps` to pass props (as attributes) to the input element, for example a data-testid
+    /** @deprecated */
     inputProps?: {[prop: string]: string};
     validate?: (value: string | void, rawValue: string | void) => string | void;
     onChangeValue?: (value: string) => void;

--- a/src/text-field-base.tsx
+++ b/src/text-field-base.tsx
@@ -50,7 +50,7 @@ export interface CommonFormFieldProps {
     name: string;
     optional?: boolean;
     maxLength?: number;
-    // use `inputProps` to pass props (as attributes) to the input element, for example a data-testid
+    /** @deprecated */
     inputProps?: {[prop: string]: string | number | undefined};
     validate?: FieldValidator;
     autoComplete?: AutoComplete;
@@ -95,7 +95,6 @@ interface TextFieldBaseProps {
     onBlur?: (event: React.FocusEvent) => void;
     onFocus?: (event: React.FocusEvent) => void;
     onKeyDown?: (event: React.KeyboardEvent) => void;
-    // to pass custom props (eg: data attributes) to input element,
     inputProps?: {[name: string]: string | number | undefined};
     inputComponent?: React.ComponentType<any>;
     shrinkLabel?: boolean;

--- a/src/text-link.tsx
+++ b/src/text-link.tsx
@@ -32,6 +32,7 @@ interface CommonProps {
     classes?: {[className: string]: string};
     small?: boolean;
     trackingEvent?: TrackingEvent | ReadonlyArray<TrackingEvent>;
+    /** @deprecated use dataAttributes */
     'data-testid'?: string;
 }
 

--- a/src/tooltip.tsx
+++ b/src/tooltip.tsx
@@ -262,7 +262,6 @@ const Tooltip: React.FC<Props> = ({children, description, target, title, targetL
                 <Portal>
                     <Overlay onPress={handleClickOutside} />
                     <div
-                        data-testid="tooltip-container"
                         role="tooltip"
                         id={ariaId}
                         className={classes.container}

--- a/src/touchable.tsx
+++ b/src/touchable.tsx
@@ -66,7 +66,7 @@ interface CommonProps {
     label?: string;
     /** @deprecated use dataAttributes */
     'data-testid'?: string;
-    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid",  */
+    /** "data-" prefix is automatically added. For example, use "testid" instead of "data-testid" */
     dataAttributes?: DataAttributes;
     'aria-checked'?: 'true' | 'false' | boolean;
     'aria-controls'?: string;

--- a/src/touchable.tsx
+++ b/src/touchable.tsx
@@ -8,6 +8,7 @@ import {ENTER, SPACE} from './utils/key-codes';
 
 import type {DataAttributes, TrackingEvent} from './utils/types';
 import type {Location} from 'history';
+import {getPrefixedDataAttributes} from './utils/dom';
 
 const redirect = (url: string, external = false): void => {
     if (external) {
@@ -125,16 +126,6 @@ export interface PropsMaybeOnPress extends CommonProps {
 }
 
 type Props = PropsHref | PropsTo | PropsOnPress | PropsMaybeHref | PropsMaybeTo | PropsMaybeOnPress;
-
-const getPrefixedDataAttributes = (attrs?: DataAttributes) => {
-    const result: DataAttributes = {};
-    if (attrs) {
-        Object.keys(attrs).forEach((key) => {
-            result['data-' + key] = attrs[key];
-        });
-    }
-    return result;
-};
 
 const Touchable: React.FC<Props> = (props) => {
     const {texts, analytics, platformOverrides, Link} = useTheme();

--- a/src/utils/dom.tsx
+++ b/src/utils/dom.tsx
@@ -1,5 +1,6 @@
 import {isServerSide} from './environment';
-import {DataAttributes} from './types';
+
+import type {DataAttributes} from './types';
 
 /**
  * Returns true if provided type is supported <input> type

--- a/src/utils/dom.tsx
+++ b/src/utils/dom.tsx
@@ -1,4 +1,5 @@
 import {isServerSide} from './environment';
+import {DataAttributes} from './types';
 
 /**
  * Returns true if provided type is supported <input> type
@@ -54,3 +55,18 @@ export const removePassiveEventListener = (
     eventName: string,
     listener: (e: any) => void
 ): void => el.removeEventListener(eventName, listener, false);
+
+/**
+ * Prefixes given attributes with `data-`
+ *
+ * For example: `{foo: 'bar'}` => `{data-foo: 'bar'}`
+ */
+export const getPrefixedDataAttributes = (attrs?: DataAttributes): DataAttributes => {
+    const result: DataAttributes = {};
+    if (attrs) {
+        Object.keys(attrs).forEach((key) => {
+            result['data-' + key] = attrs[key];
+        });
+    }
+    return result;
+};


### PR DESCRIPTION
instead of defining `data-whatever` props in our components, we want to use a dictionary `dataProperties` to be able to pass any `data attribute` to the component