### PR TITLE
feat(FormFields): use rifm to format CreditCard and Decimal fields

### DIFF
--- a/flow-defs/integer-field.js.flow
+++ b/flow-defs/integer-field.js.flow
@@ -2,11 +2,7 @@
 
 import * as React from "react";
 import type { CommonFormFieldProps } from "./text-field-base";
-declare type Props = $Diff<any, { value: *, onInput: * }> & {
-  inputRef?: React.Ref<HTMLInputElement>,
-  value?: string,
-};
-declare export var IntegerInput: React.ComponentType<Props>;
+declare export var IntegerInput: React.ComponentType<any>;
 export type IntegerFieldProps = {|
   ...$Exact<CommonFormFieldProps>,
 

--- a/flow-defs/integer-field.js.flow
+++ b/flow-defs/integer-field.js.flow
@@ -2,6 +2,11 @@
 
 import * as React from "react";
 import type { CommonFormFieldProps } from "./text-field-base";
+declare type Props = $Diff<any, { value: *, onInput: * }> & {
+  inputRef?: React.Ref<HTMLInputElement>,
+  value?: string,
+};
+declare export var IntegerInput: React.ComponentType<Props>;
 export type IntegerFieldProps = {|
   ...$Exact<CommonFormFieldProps>,
 

--- a/size-stats.json
+++ b/size-stats.json
@@ -1,15 +1,15 @@
 {
     "dist": {
-        "js": "5421.32 KB",
-        "jsNoMisticaIcons": "771.00 KB"
+        "js": "5424.21 KB",
+        "jsNoMisticaIcons": "773.90 KB"
     },
     "distEs": {
-        "js": "3106.09 KB",
-        "jsNoMisticaIcons": "569.15 KB"
+        "js": "3108.80 KB",
+        "jsNoMisticaIcons": "571.86 KB"
     },
     "libOverhead": {
         "initial": "127.79 KB",
-        "withMistica": "265.27 KB",
-        "difference": "137.48 KB"
+        "withMistica": "265.39 KB",
+        "difference": "137.60 KB"
     }
 }

--- a/src/__acceptance_tests__/form-fields-acceptance-test.tsx
+++ b/src/__acceptance_tests__/form-fields-acceptance-test.tsx
@@ -62,6 +62,15 @@ test.each(STORY_TYPES)('DecimalField (%s)', async (storyType) => {
 
     await clearAndType(page, field, '+-123e.4,5.6i');
     await expect(getValue(field)).resolves.toBe('123,456');
+
+    await clearAndType(page, field, '124,5');
+    await expect(getValue(field)).resolves.toBe('124,5');
+    await field.evaluate((el) => {
+        // set the caret position after the first block
+        (el as HTMLInputElement).setSelectionRange(2, 2);
+    });
+    await field.type('.3');
+    await expect(getValue(field)).resolves.toBe('12,345');
 });
 
 test.each(STORY_TYPES)('CreditCardNumberField (%s)', async (storyType) => {

--- a/src/__acceptance_tests__/form-fields-acceptance-test.tsx
+++ b/src/__acceptance_tests__/form-fields-acceptance-test.tsx
@@ -74,6 +74,15 @@ test.each(STORY_TYPES)('CreditCardNumberField (%s)', async (storyType) => {
 
     await clearAndType(page, field, '1234-567.8 9012/34abc567 890');
     await expect(getValue(field)).resolves.toBe('1234 5678 9012 3456');
+
+    await clearAndType(page, field, '123456789012');
+    await expect(getValue(field)).resolves.toBe('1234 5678 9012');
+    await field.evaluate((el) => {
+        // set the caret position after the first block
+        (el as HTMLInputElement).setSelectionRange(4, 4);
+    });
+    await field.type('1234');
+    await expect(getValue(field)).resolves.toBe('1234 1234 5678 9012');
 });
 
 test.each(STORY_TYPES)('CreditCardExpirationField (%s)', async (storyType) => {

--- a/src/__acceptance_tests__/form-fields-acceptance-test.tsx
+++ b/src/__acceptance_tests__/form-fields-acceptance-test.tsx
@@ -63,14 +63,25 @@ test.each(STORY_TYPES)('DecimalField (%s)', async (storyType) => {
     await clearAndType(page, field, '+-123e.4,5.6i');
     await expect(getValue(field)).resolves.toBe('123,456');
 
+    // test editing the number to set the decimal char in a previous pos
     await clearAndType(page, field, '124,5');
     await expect(getValue(field)).resolves.toBe('124,5');
     await field.evaluate((el) => {
-        // set the caret position after the first block
+        // set the caret position on a digit before the ,
         (el as HTMLInputElement).setSelectionRange(2, 2);
     });
     await field.type('.3');
     await expect(getValue(field)).resolves.toBe('12,345');
+
+    // test editing the number to set the decimal char in a later pos
+    await clearAndType(page, field, '1,24');
+    await expect(getValue(field)).resolves.toBe('1,24');
+    await field.evaluate((el) => {
+        // set the caret position on a digit after the ,
+        (el as HTMLInputElement).setSelectionRange(3, 3);
+    });
+    await field.type('.3');
+    await expect(getValue(field)).resolves.toBe('1,234'); // only the first , should be considered.
 });
 
 test.each(STORY_TYPES)('CreditCardNumberField (%s)', async (storyType) => {

--- a/src/credit-card-number-field.tsx
+++ b/src/credit-card-number-field.tsx
@@ -64,7 +64,7 @@ const CreditCardInput: React.FC<Props> = ({inputRef, value, defaultValue, onChan
             {...other}
             type="text"
             inputMode="decimal"
-            maxLength={getCreditCardNumberLength(rifm.value) + 3} // We have to take in account formatting spaces
+            maxLength={getCreditCardNumberLength(rifm.value) + 3} // We have to take into account formatting spaces
             onChange={rifm.onChange}
             value={rifm.value}
             ref={combineRefs(inputRef, ref)}

--- a/src/cvv-field.tsx
+++ b/src/cvv-field.tsx
@@ -8,7 +8,7 @@ import IconButton from './icon-button';
 import IcnInfo from './icons/icon-info-cvv';
 import {useFieldProps, useForm} from './form-context';
 import TextFieldBase from './text-field-base';
-import {DecimalInput} from './decimal-field';
+import {IntegerInput} from './integer-field';
 
 import type {CommonFormFieldProps} from './text-field-base';
 import type {CardOptions} from './utils/credit-card';
@@ -142,7 +142,7 @@ const CvvField: React.FC<CvvFieldProps> = ({
                 />
             }
             autoComplete={autoComplete}
-            inputComponent={DecimalInput}
+            inputComponent={IntegerInput}
         />
     );
 };

--- a/src/decimal-field.tsx
+++ b/src/decimal-field.tsx
@@ -18,6 +18,8 @@ const getLocalDecimalChar = (locale: Locale): string => {
 };
 
 const format = (value: any) => {
+    // do not make the localDecimalChar replacement here. Instead, keep the one the user typed.
+    // Make that replacement in `replace` prost-processor. It is what rifm lib expects.
     const sanitized = String(value ?? '').replace(/[^.,\d]/g, ''); // remove non digits or decimal separator chars;
     const firstSeparator = /[.,]/.exec(sanitized);
     const parts = sanitized.split(/[.,]/);

--- a/src/decimal-field.tsx
+++ b/src/decimal-field.tsx
@@ -17,6 +17,25 @@ const getLocalDecimalChar = (locale: Locale): string => {
     }
 };
 
+const format = (value: any) => {
+    const sanitized = String(value ?? '').replace(/[^.,\d]/g, ''); // remove non digits or decimal separator chars;
+    const firstSeparator = /[.,]/.exec(sanitized);
+    const parts = sanitized.split(/[.,]/);
+
+    if (parts.length === 0) {
+        // empty
+        return '';
+    }
+
+    if (firstSeparator) {
+        // value includes one or more decimal separators, keep the first one
+        return parts.shift() + firstSeparator[0] + parts.join('');
+    } else {
+        // no fractional part, return "as is"
+        return parts[0];
+    }
+};
+
 /**
  * typed as `any` because `React.HTMLProps<>` has no equivalent in flowtype
  * not a big problem because this component is not exported to the public API
@@ -36,25 +55,6 @@ export const DecimalInput: React.FC<DecimalInputProps> = ({
 }) => {
     const {i18n} = useTheme();
     const localDecimalChar = getLocalDecimalChar(i18n.locale);
-
-    const format = (value: any) => {
-        const parts = String(value ?? '')
-            .replace(/[^.,\d]/g, '') // remove non digits or decimal separator chars
-            .split(localDecimalChar);
-
-        if (parts.length === 0) {
-            // empty
-            return '';
-        }
-
-        if (parts.length === 1) {
-            // no fractional part, return "as is"
-            return parts[0];
-        }
-
-        // value includes one or more decimal separators, keep the first one
-        return parts.shift() + localDecimalChar + parts.join('');
-    };
 
     const replace = (value: any) => String(value ?? '').replace(/[.,]/g, localDecimalChar); // use local decimal char
 

--- a/src/integer-field.tsx
+++ b/src/integer-field.tsx
@@ -5,7 +5,12 @@ import TextFieldBase from './text-field-base';
 
 import type {CommonFormFieldProps} from './text-field-base';
 
-export const IntegerInput: React.FC<any> = ({inputRef, value, defaultValue, ...rest}: any) => {
+type Props = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onInput'> & {
+    inputRef?: React.Ref<HTMLInputElement>;
+    value?: string;
+};
+
+export const IntegerInput: React.FC<Props> = ({inputRef, value, defaultValue, ...rest}: any) => {
     const format = (v?: string) => String(v ?? '').replace(/[^\d]/g, '');
 
     const handleInput = (e: React.FormEvent<HTMLInputElement>) => {

--- a/src/integer-field.tsx
+++ b/src/integer-field.tsx
@@ -5,7 +5,7 @@ import TextFieldBase from './text-field-base';
 
 import type {CommonFormFieldProps} from './text-field-base';
 
-const IntegerInput = ({inputRef, value, defaultValue, ...rest}: any) => {
+export const IntegerInput: React.FC<any> = ({inputRef, value, defaultValue, ...rest}: any) => {
     const format = (v?: string) => String(v ?? '').replace(/[^\d]/g, '');
 
     const handleInput = (e: React.FormEvent<HTMLInputElement>) => {

--- a/src/integer-field.tsx
+++ b/src/integer-field.tsx
@@ -5,12 +5,7 @@ import TextFieldBase from './text-field-base';
 
 import type {CommonFormFieldProps} from './text-field-base';
 
-type Props = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onInput'> & {
-    inputRef?: React.Ref<HTMLInputElement>;
-    value?: string;
-};
-
-export const IntegerInput: React.FC<Props> = ({inputRef, value, defaultValue, ...rest}: any) => {
+export const IntegerInput: React.FC<any> = ({inputRef, value, defaultValue, ...rest}: any) => {
     const format = (v?: string) => String(v ?? '').replace(/[^\d]/g, '');
 
     const handleInput = (e: React.FormEvent<HTMLInputElement>) => {


### PR DESCRIPTION
related to #191 

Applied to CreditCardInput and DecimalInput (used by CvvField). Not applied to CreditCardExpirationField since it provokes more problems than what it solves...
**before**
![creditcardfields-before-rifm](https://user-images.githubusercontent.com/681159/127483412-16be6c55-2a5c-4491-ab0d-dec4f8b8f653.gif)

**after**
![creditcardfields-after-rifm](https://user-images.githubusercontent.com/681159/127483440-5d818ed8-565f-4b58-ab91-ef5ffa1ecc71.gif)


