### PR TITLE
feat(mq.suportsHover): include mq for devices that support hover

### DIFF
--- a/flow-defs/theme.js.flow
+++ b/flow-defs/theme.js.flow
@@ -129,6 +129,7 @@ export type Theme = {
     tabletOrBigger: string,
     tabletOrSmaller: string,
     desktopOrBigger: string,
+    supportsHover: string,
   },
   colors: Colors,
   Link: LinkComponent,

--- a/flow-defs/utils/media-queries.js.flow
+++ b/flow-defs/utils/media-queries.js.flow
@@ -13,4 +13,5 @@ declare export var createMediaQueries: (x: {
   tabletOrBigger: string,
   tabletOrSmaller: string,
   desktopOrBigger: string,
+  supportsHover: string,
 };

--- a/playroom/components.tsx
+++ b/playroom/components.tsx
@@ -63,7 +63,7 @@ const useControlsStyles = createUseStyles((theme) => ({
     },
 }));
 
-const useStyles = createUseStyles(() => ({
+const useStyles = createUseStyles((theme) => ({
     floattingButton: {
         position: 'fixed',
         zIndex: 1,
@@ -73,9 +73,11 @@ const useStyles = createUseStyles(() => ({
         left: ({position}) => (position.endsWith('left') ? 0 : 'initial'),
         opacity: 0.3,
         '& *': {outline: 'none'},
-        '&:hover': {
-            opacity: 1,
-            transform: 'rotateZ(45deg)',
+        [theme.mq.supportsHover]: {
+            '&:hover': {
+                opacity: 1,
+                transform: 'rotateZ(45deg)',
+            },
         },
         transition: 'transform 0.3s ease-in-out, opacity 0.3s ease-in-out',
     },

--- a/size-stats.json
+++ b/size-stats.json
@@ -1,15 +1,15 @@
 {
     "dist": {
-        "js": "5531.23 KB",
-        "jsNoMisticaIcons": "829.57 KB"
+        "js": "5530.14 KB",
+        "jsNoMisticaIcons": "828.47 KB"
     },
     "distEs": {
-        "js": "3182.94 KB",
-        "jsNoMisticaIcons": "619.82 KB"
+        "js": "3181.88 KB",
+        "jsNoMisticaIcons": "618.76 KB"
     },
     "libOverhead": {
         "initial": "127.79 KB",
-        "withMistica": "272.69 KB",
-        "difference": "144.90 KB"
+        "withMistica": "272.75 KB",
+        "difference": "144.96 KB"
     }
 }

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -24,13 +24,9 @@ import {getPrefixedDataAttributes} from './utils/dom';
 
 import type {DataAttributes, TrackingEvent} from './utils/types';
 
-const useStyles = createUseStyles(({colors}) => ({
+const useStyles = createUseStyles(({colors, mq}) => ({
     hover: {
-        // Only apply hover effect to user agents using fine pointer devices (a mouse, for example)
-        // Also enabled for (pointer: none) for acceptance tests, where (pointer: fine) doesn't match.
-        // WARNING: you may be tempted to use @media (hover: hover) instead, but that doesn't work as expected in some android browsers.
-        // See: https://hover-pointer-media-query.glitch.me/ and https://github.com/mui-org/material-ui/issues/15736
-        '@media (pointer: fine), (pointer: none)': {
+        [mq.supportsHover]: {
             '&:hover': {
                 background: ({isInverse}) => (isInverse ? 'initial' : colors.backgroundAlternative),
             },
@@ -538,7 +534,7 @@ const RowContent = (props: RowContentProps) => {
     return (
         <Box
             paddingX={16}
-            className={classNames(classNames(classes.rowContent, classes.hover), classes.hoverDisabled)}
+            className={classNames(classes.rowContent, classes.hover, classes.hoverDisabled)}
             role={role}
         >
             {props.right

--- a/src/navigation-bar.tsx
+++ b/src/navigation-bar.tsx
@@ -226,11 +226,7 @@ const useStyles = createUseStyles((theme) => {
             borderBottom: `2px solid transparent`,
             transition: 'border-color 300ms ease-in-out',
 
-            // Only apply hover effect to user agents using fine pointer devices (a mouse, for example)
-            // Also enabled for (pointer: none) for acceptance tests, where (pointer: fine) doesn't match.
-            // WARNING: you may be tempted to use @media (hover: hover) instead, but that doesn't work as expected in some android browsers.
-            // See: https://hover-pointer-media-query.glitch.me/ and https://github.com/mui-org/material-ui/issues/15736
-            '@media (pointer: fine), (pointer: none)': {
+            [theme.mq.supportsHover]: {
                 '&:hover span': {
                     color: ({isInverse}) =>
                         isInverse ? theme.colors.textSecondaryInverse : theme.colors.textSecondary,
@@ -273,11 +269,7 @@ const useStyles = createUseStyles((theme) => {
         },
         iconButton: {
             color: ({isInverse}) => (isInverse ? theme.colors.inverse : theme.colors.neutralHigh),
-            // Only apply hover effect to user agents using fine pointer devices (a mouse, for example)
-            // Also enabled for (pointer: none) for acceptance tests, where (pointer: fine) doesn't match.
-            // WARNING: you may be tempted to use @media (hover: hover) instead, but that doesn't work as expected in some android browsers.
-            // See: https://hover-pointer-media-query.glitch.me/ and https://github.com/mui-org/material-ui/issues/15736
-            '@media (pointer: fine), (pointer: none)': {
+            [theme.mq.supportsHover]: {
                 '&:hover': {
                     color: ({isInverse}) => (isInverse ? theme.colors.inverse : theme.colors.neutralMedium),
                 },
@@ -576,11 +568,7 @@ const useNavigationBarActionStyles = createUseStyles((theme) => ({
             color: ({isInverse}) => (isInverse ? theme.colors.inverse : theme.colors.neutralHigh),
         },
 
-        // Only apply hover effect to user agents using fine pointer devices (a mouse, for example)
-        // Also enabled for (pointer: none) for acceptance tests, where (pointer: fine) doesn't match.
-        // WARNING: you may be tempted to use @media (hover: hover) instead, but that doesn't work as expected in some android browsers.
-        // See: https://hover-pointer-media-query.glitch.me/ and https://github.com/mui-org/material-ui/issues/15736
-        '@media (pointer: fine), (pointer: none)': {
+        [theme.mq.supportsHover]: {
             '&:hover span': {
                 color: ({isInverse}) =>
                     isInverse ? theme.colors.textSecondaryInverse : theme.colors.textSecondary,

--- a/src/password-field.tsx
+++ b/src/password-field.tsx
@@ -13,13 +13,9 @@ export interface PasswordFieldProps extends CommonFormFieldProps {
     onChangeValue?: (value: string, rawValue: string) => void;
 }
 
-const usePasswordAdornmentStyles = createUseStyles(() => ({
+const usePasswordAdornmentStyles = createUseStyles((theme) => ({
     shadow: {
-        // Only apply hover effect to user agents using fine pointer devices (a mouse, for example)
-        // Also enabled for (pointer: none) for acceptance tests, where (pointer: fine) doesn't match.
-        // WARNING: you may be tempted to use @media (hover: hover) instead, but that doesn't work as expected in some android browsers.
-        // See: https://hover-pointer-media-query.glitch.me/ and https://github.com/mui-org/material-ui/issues/15736
-        ['@media (pointer: fine), (pointer: none)']: {
+        [theme.mq.supportsHover]: {
             '&:hover': {
                 backgroundColor: 'rgba(0, 0, 0, 0.08)',
             },

--- a/src/select.tsx
+++ b/src/select.tsx
@@ -92,8 +92,10 @@ const useStyles = createUseStyles((theme) => ({
         padding: '6px 16px',
         height: 48,
         transition: 'background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-        '&:hover': {
-            backgroundColor: 'rgba(0, 0, 0, 0.08)',
+        [theme.mq.supportsHover]: {
+            '&:hover': {
+                backgroundColor: 'rgba(0, 0, 0, 0.08)',
+            },
         },
         display: 'flex',
         alignItems: 'center',

--- a/src/tabs.tsx
+++ b/src/tabs.tsx
@@ -60,8 +60,10 @@ const useStyles = createUseStyles(({colors, mq}) => ({
             }
             return TAB_MAX_WIDTH;
         },
-        '&:hover': {
-            color: colors.textPrimary,
+        [mq.supportsHover]: {
+            '&:hover': {
+                color: colors.textPrimary,
+            },
         },
         fallbacks: {
             maxWidth: TAB_MAX_WIDTH, // max() is not supported by all browsers

--- a/src/text-link.tsx
+++ b/src/text-link.tsx
@@ -13,11 +13,9 @@ const useStyles = createUseStyles((theme) => ({
         display: 'inline-block',
         color: theme.colors.textLink,
         wordBreak: 'break-word',
-        '&:hover': {
-            textDecoration: 'underline',
-            // Revert hover effect in touch devices
-            '@media (pointer: coarse)': {
-                textDecoration: 'initial',
+        [theme.mq.supportsHover]: {
+            '&:hover': {
+                textDecoration: 'underline',
             },
         },
     },

--- a/src/theme-context-provider.tsx
+++ b/src/theme-context-provider.tsx
@@ -113,9 +113,7 @@ const ThemeContextProvider: React.FC<Props> = ({theme, children}) => {
                 ...dimensions,
                 ...theme.dimensions,
             },
-            mq: theme.mediaQueries
-                ? createMediaQueries(theme.mediaQueries)
-                : createMediaQueries(mediaQueriesConfig),
+            mq: createMediaQueries(theme.mediaQueries ?? mediaQueriesConfig),
             colors,
             Link: theme.Link ?? AnchorLink,
             isDarkMode: isDarkModeEnabled,

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -245,6 +245,7 @@ export type Theme = {
         tabletOrBigger: string;
         tabletOrSmaller: string;
         desktopOrBigger: string;
+        supportsHover: string;
     };
     colors: Colors;
     Link: LinkComponent;

--- a/src/utils/media-queries.tsx
+++ b/src/utils/media-queries.tsx
@@ -16,6 +16,7 @@ export const createMediaQueries = ({
     tabletOrBigger: string;
     tabletOrSmaller: string;
     desktopOrBigger: string;
+    supportsHover: string;
 } => ({
     mobile:
         `@media only screen and (max-width: ${tabletMinWidth - 1}px), ` +
@@ -48,4 +49,10 @@ export const createMediaQueries = ({
         `@media only screen ` +
         `and (min-height: ${desktopOrTabletMinHeight}px) ` +
         `and (min-width: ${desktopMinWidth}px)`,
+
+    // Only apply hover effect to user agents using fine pointer devices (a mouse, for example)
+    // Also enabled for (pointer: none) for acceptance tests, where (pointer: fine) doesn't match.
+    // WARNING: you may be tempted to use @media (hover: hover) instead, but that doesn't work as expected in some android browsers.
+    // See: https://hover-pointer-media-query.glitch.me/ and https://github.com/mui-org/material-ui/issues/15736
+    supportsHover: '@media (pointer: fine), (pointer: none)',
 });


### PR DESCRIPTION
I've extracted the `@media (pointer: fine), (pointer: none)` media query that we used in some components to apply hover styles to a common place and exposed it in theme context.

Applied the media query to some componente where we weren't using it, like `Tabs`