### PR TITLE
feat(Feedback): show info/error icons in vivo

### DIFF
--- a/src/feedback.tsx
+++ b/src/feedback.tsx
@@ -364,13 +364,8 @@ export const ErrorFeedbackScreen: React.FC<ErrorFeedbackScreenProps> = ({
     ...otherProps
 }) => {
     const {colors} = useTheme();
-     return (
-        <FeedbackScreen
-            {...otherProps}
-            hapticFeedback="error"
-            icon={<IcnError />}
-            animateText
-        >
+    return (
+        <FeedbackScreen {...otherProps} hapticFeedback="error" icon={<IcnError />} animateText>
             {children}
             {errorReference && (
                 <Text2 color={colors.textSecondary} regular>

--- a/src/feedback.tsx
+++ b/src/feedback.tsx
@@ -363,13 +363,12 @@ export const ErrorFeedbackScreen: React.FC<ErrorFeedbackScreenProps> = ({
     errorReference,
     ...otherProps
 }) => {
-    const {skinName, colors} = useTheme();
-    const hasIcon = skinName !== VIVO_SKIN;
-    return (
+    const {colors} = useTheme();
+     return (
         <FeedbackScreen
             {...otherProps}
             hapticFeedback="error"
-            icon={hasIcon ? <IcnError /> : undefined}
+            icon={<IcnError />}
             animateText
         >
             {children}
@@ -383,9 +382,7 @@ export const ErrorFeedbackScreen: React.FC<ErrorFeedbackScreenProps> = ({
 };
 
 export const InfoFeedbackScreen: React.FC<FeedbackProps> = (props) => {
-    const {skinName} = useTheme();
-    const hasIcon = skinName !== VIVO_SKIN;
-    return <FeedbackScreen {...props} icon={hasIcon ? <IcnInfo /> : undefined} />;
+    return <FeedbackScreen {...props} icon={<IcnInfo />} />;
 };
 
 export const SuccessFeedback: React.FC<AssetFeedbackProps> = ({


### PR DESCRIPTION
Now Vivo's info and error feedback screens will use the same icons as the others.