### PR TITLE
[Proposal] Row with renderRight and centerY

### DIFF
--- a/src/__stories__/list-story.tsx
+++ b/src/__stories__/list-story.tsx
@@ -12,6 +12,9 @@ import {
     IconLikeFilled,
     IconLightningRegular,
     Image,
+    Text3,
+    Inline,
+    IconChevron,
 } from '..';
 
 export default {
@@ -27,6 +30,7 @@ export default {
                 'checkbox and onPress',
                 'radio',
                 'custom element',
+                'custom element with text',
                 'action with custom element',
                 'none',
             ],
@@ -74,7 +78,7 @@ const Template: StoryComponent<Args & {boxed?: boolean}> = ({
                 controlProps = {href: 'https://example.org', newTab: true};
                 break;
             case 'navigates without chevron':
-                controlProps = {href: 'https://example.org', newTab: true, right: null}; // right null removes the chevron
+                controlProps = {href: 'https://example.org', newTab: true, renderRight: null}; // renderRight null removes the chevron
                 break;
             case 'switch':
                 controlProps = {switch: {defaultValue: true, onChange: () => {}}};
@@ -96,9 +100,23 @@ const Template: StoryComponent<Args & {boxed?: boolean}> = ({
                 break;
             case 'custom element':
                 controlProps = {
-                    right: (
+                    renderRight: () => (
                         <div style={{display: 'flex', alignItems: 'center', height: '100%'}}>
                             <div style={{width: 32, height: 32, borderRadius: '50%', background: 'pink'}} />
+                        </div>
+                    ),
+                };
+                break;
+            case 'custom element with text':
+                controlProps = {
+                    renderRight: ({centerY}: {centerY: boolean}) => (
+                        <div style={centerY ? {display: 'flex', alignItems: 'center', height: '100%'} : {}}>
+                            <Inline space={0}>
+                                <Text3 color={colors.error} medium as="p">
+                                    12,00 €
+                                </Text3>
+                                <IconChevron direction="right" color={colors.neutralMedium} />
+                            </Inline>
                         </div>
                     ),
                 };
@@ -106,7 +124,7 @@ const Template: StoryComponent<Args & {boxed?: boolean}> = ({
             case 'action with custom element':
                 controlProps = {
                     onPress,
-                    right: (
+                    renderRight: () => (
                         <div style={{display: 'flex', alignItems: 'center', height: '100%'}}>
                             <div style={{width: 32, height: 32, borderRadius: '50%', background: 'pink'}} />
                         </div>

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -127,7 +127,7 @@ interface CommonProps {
 interface ContentProps extends CommonProps {
     isClickable?: boolean;
     type?: 'chevron' | 'basic' | 'custom' | 'control';
-    right?: React.ReactNode;
+    renderRight?: ({centerY}: {centerY: boolean}) => React.ReactNode;
     /** This id is to link the title with the related control */
     labelId?: string;
 }
@@ -143,7 +143,7 @@ const Content: React.FC<ContentProps> = ({
     asset,
     type = 'basic',
     badge,
-    right,
+    renderRight,
     extra,
     labelId,
     disabled,
@@ -152,7 +152,7 @@ const Content: React.FC<ContentProps> = ({
     const classes = useStyles({isInverse});
     const {colors} = useTheme();
     const numTextLines = [headline, title, subtitle, description, extra].filter(Boolean).length;
-    const shouldCenter = numTextLines === 1;
+    const centerY = numTextLines === 1;
 
     const renderBadge = () => {
         if (!badge) {
@@ -167,44 +167,19 @@ const Content: React.FC<ContentProps> = ({
         );
     };
 
-    const renderRight = () => {
-        switch (type) {
-            case 'chevron':
-                return (
-                    <Box
-                        paddingLeft={16}
-                        className={classNames(classes.center, {[classes.disabled]: disabled})}
-                    >
-                        <IconChevron
-                            color={isInverse ? colors.inverse : colors.neutralMedium}
-                            direction="right"
-                        />
-                    </Box>
-                );
-            case 'control':
-                return <div className={classes.right}>{right}</div>;
-            case 'custom':
-                return (
-                    <div className={classNames(classes.right, {[classes.disabled]: disabled})}>{right}</div>
-                );
-            default:
-                return null;
-        }
-    };
-
     return (
         <Box paddingY={16} className={classes.content}>
             {asset && (
                 <Box
                     paddingRight={16}
-                    className={classNames({[classes.center]: shouldCenter, [classes.disabled]: disabled})}
+                    className={classNames({[classes.center]: centerY, [classes.disabled]: disabled})}
                 >
                     <div className={classes.asset}>{asset}</div>
                 </Box>
             )}
             <div
                 className={classNames(classes.rowBody, {[classes.disabled]: disabled})}
-                style={{justifyContent: shouldCenter ? 'center' : 'flex-start'}}
+                style={{justifyContent: centerY ? 'center' : 'flex-start'}}
             >
                 <Stack space={4}>
                     {headline && (
@@ -242,7 +217,20 @@ const Content: React.FC<ContentProps> = ({
                 </Stack>
             </div>
             {renderBadge()}
-            {renderRight()}
+            {type === 'chevron' && (
+                <Box paddingLeft={16} className={classNames(classes.center, {[classes.disabled]: disabled})}>
+                    <IconChevron
+                        color={isInverse ? colors.inverse : colors.neutralMedium}
+                        direction="right"
+                    />
+                </Box>
+            )}
+            {type === 'control' && <div className={classes.right}>{renderRight?.({centerY})}</div>}
+            {type === 'custom' && (
+                <div className={classNames(classes.right, {[classes.disabled]: disabled})}>
+                    {renderRight?.({centerY})}
+                </div>
+            )}
         </Box>
     );
 };
@@ -264,14 +252,14 @@ interface BasicRowContentProps extends CommonProps {
     newTab?: undefined;
     fullPageOnWebView?: undefined;
 
-    right?: React.ReactNode;
+    renderRight?: ({centerY}: {centerY: boolean}) => React.ReactNode;
 }
 
 interface SwitchRowContentProps extends CommonProps {
     href?: undefined;
     onPress?: () => void;
     to?: undefined;
-    right?: undefined;
+    renderRight?: undefined;
     checkbox?: undefined;
     radioValue?: undefined;
     newTab?: undefined;
@@ -284,7 +272,7 @@ interface CheckboxRowContentProps extends CommonProps {
     href?: undefined;
     onPress?: () => void;
     to?: undefined;
-    right?: undefined;
+    renderRight?: undefined;
     switch?: undefined;
     radioValue?: undefined;
     newTab?: undefined;
@@ -297,7 +285,7 @@ interface RadioRowContentProps extends CommonProps {
     href?: undefined;
     onPress?: undefined;
     to?: undefined;
-    right?: undefined;
+    renderRight?: undefined;
     switch?: undefined;
     checkbox?: undefined;
     newTab?: undefined;
@@ -317,7 +305,7 @@ interface HrefRowContentProps extends CommonProps {
     newTab?: boolean;
     onPress?: undefined;
     to?: undefined;
-    right?: React.ReactNode;
+    renderRight?: ({centerY}: {centerY: boolean}) => React.ReactNode;
 }
 
 interface ToRowContentProps extends CommonProps {
@@ -332,7 +320,7 @@ interface ToRowContentProps extends CommonProps {
     replace?: boolean;
     href?: undefined;
     onPress?: undefined;
-    right?: React.ReactNode;
+    renderRight?: ({centerY}: {centerY: boolean}) => React.ReactNode;
 }
 
 interface OnPressRowContentProps extends CommonProps {
@@ -345,7 +333,7 @@ interface OnPressRowContentProps extends CommonProps {
     onPress: () => void;
     href?: undefined;
     to?: undefined;
-    right?: React.ReactNode;
+    renderRight?: ({centerY}: {centerY: boolean}) => React.ReactNode;
 }
 
 type RowContentProps =
@@ -415,11 +403,11 @@ const RowContent = React.forwardRef<HTMLDivElement | HTMLAnchorElement | HTMLBut
 
         const renderContent = ({
             type,
-            right,
+            renderRight,
             labelId,
         }: {
             type: ContentProps['type'];
-            right?: ContentProps['right'];
+            renderRight?: ContentProps['renderRight'];
             labelId?: string;
         }) => (
             <Content
@@ -433,7 +421,7 @@ const RowContent = React.forwardRef<HTMLDivElement | HTMLAnchorElement | HTMLBut
                 subtitleLinesMax={subtitleLinesMax}
                 descriptionLinesMax={descriptionLinesMax}
                 type={type}
-                right={right}
+                renderRight={renderRight}
                 extra={extra}
                 labelId={labelId}
                 disabled={disabled}
@@ -445,17 +433,17 @@ const RowContent = React.forwardRef<HTMLDivElement | HTMLAnchorElement | HTMLBut
         ) => {
             let type: ContentProps['type'] = 'chevron';
 
-            if (props.right === null) {
+            if (props.renderRight === null) {
                 type = 'basic';
             }
 
-            if (props.right) {
+            if (props.renderRight) {
                 type = 'custom';
             }
 
             return (
                 <Box paddingX={16} ref={ref as React.Ref<HTMLDivElement>}>
-                    {renderContent({type, right: props.right})}
+                    {renderContent({type, renderRight: props.renderRight})}
                 </Box>
             );
         };
@@ -553,7 +541,7 @@ const RowContent = React.forwardRef<HTMLDivElement | HTMLAnchorElement | HTMLBut
                                 {renderContent({
                                     labelId,
                                     type: 'control',
-                                    right: <Stack space="around">{control}</Stack>,
+                                    renderRight: () => <Stack space="around">{control}</Stack>,
                                 })}
                             </Box>
                         )}
@@ -585,7 +573,7 @@ const RowContent = React.forwardRef<HTMLDivElement | HTMLAnchorElement | HTMLBut
                             <Box paddingX={16}>
                                 {renderContent({
                                     type: 'control',
-                                    right: <Stack space="around">{radio}</Stack>,
+                                    renderRight: () => <Stack space="around">{radio}</Stack>,
                                 })}
                             </Box>
                         )}
@@ -600,8 +588,8 @@ const RowContent = React.forwardRef<HTMLDivElement | HTMLAnchorElement | HTMLBut
                 className={classNames(classes.rowContent, classes.hover, classes.hoverDisabled)}
                 role={role}
             >
-                {props.right
-                    ? renderContent({type: 'custom', right: props.right})
+                {props.renderRight
+                    ? renderContent({type: 'custom', renderRight: props.renderRight})
                     : renderContent({type: 'basic'})}
             </Box>
         );


### PR DESCRIPTION
Useful information to render properly the right side of the row.

## Issue

Custom text on the `right` side of a `Row` isn't properly aligned with the other texts on the main content.
Look at the "12,00 €" red texts here:
![image](https://user-images.githubusercontent.com/4521712/151944146-3c80ca77-fa87-4444-bf59-5f6fd5800392.png)

## Proposal

Expose the `centerY` flag so consumers can properly align their elements on the right side through the `renderRight` render callback.

| Single text | Multiple texts |
| - | - |
| ![single-text](https://user-images.githubusercontent.com/4521712/151943935-6407e317-9a3b-43ee-a43b-d31807111339.png) | ![multiple-texts](https://user-images.githubusercontent.com/4521712/151943970-737f7cbb-6f4e-4834-b39d-a2672a2b1579.png) |