### PR TITLE
fix(Form fields): use rawValue to check if a form field is empty

### DIFF
--- a/src/form.tsx
+++ b/src/form.tsx
@@ -86,7 +86,7 @@ const Form: React.FC<FormProps> = ({
                 if (input.disabled) {
                     continue;
                 }
-                if (input.required && !input.value.trim()) {
+                if (input.required && !rawValues[name].trim()) {
                     errors[name] = texts.formFieldErrorIsMandatory;
                 } else {
                     const error = validator?.(values[name], rawValues[name]);


### PR DESCRIPTION
## Why this change?

Because when creating custom inputs (from TextFieldBase), even if you use a custom validator function, the default validation (the one that happens when input is required and is value in not empty) take place. In new inputs chips the actual input value could be an empty string, because the real value (and array of string) will live in the form's state. 

So, instead of reading the reading the current input value, real the value that lives in the form state (that is the one that will also be used in onSubmit)