### PR TITLE
fix(Popover): bug with close event propagation

### DIFF
--- a/src/popover.tsx
+++ b/src/popover.tsx
@@ -254,12 +254,6 @@ const Popover: React.FC<Props> = ({
         setTargetPosition(getTargetPosition(targetWrapperRef.current));
     }, [isVisible]);
 
-    const handleClose = () => {
-        if (onClose) {
-            onClose();
-        }
-    };
-
     let popoverContainer = null;
 
     if (isVisible && targetPosition) {
@@ -289,7 +283,10 @@ const Popover: React.FC<Props> = ({
                     </div>
                     <div className={classes.closeButtonIcon}>
                         <IconButton
-                            onPress={handleClose}
+                            onPress={(e) => {
+                                onClose?.();
+                                e.stopPropagation();
+                            }}
                             trackingEvent={trackingEvent}
                             aria-label={texts.modalClose}
                         >


### PR DESCRIPTION
When the user clicks on the close icon, the popover closes but the underlying component, if it is touchable, gets actionated too.

Here you can see a `Popover` over the `AgreementSelector`, and when I close the popover, the agreement selector gets actionated too:

https://user-images.githubusercontent.com/4521712/154485133-a3c8096a-eda8-4b93-9df6-eb757588bbe9.mp4

