### PR TITLE
fix(Slideshow): scroll snap stop on android

### DIFF
--- a/src/carousel.tsx
+++ b/src/carousel.tsx
@@ -553,6 +553,7 @@ const useSlideshowStyles = createUseStyles((theme) => ({
     },
     item: {
         width: '100%',
+        scrollSnapStop: isAndroid(theme.platformOverrides) ? 'always' : 'normal',
         scrollSnapAlign: 'start',
         flexShrink: 0,
     },


### PR DESCRIPTION
this same [fix](https://github.com/Telefonica/mistica-web/pull/430#discussion_r816005422) but applied to `Slideshow` too