### PR TITLE
fix(types): make skin in ThemeConfig readonly

### DIFF
--- a/flow-defs/theme.js.flow
+++ b/flow-defs/theme.js.flow
@@ -79,7 +79,7 @@ declare type LinkComponent = React.ComponentType<{
 declare export var AnchorLink: LinkComponent;
 export type ColorScheme = "dark" | "light" | "auto";
 export type ThemeConfig = {
-  skin: Skin,
+  skin: $ReadOnly<Skin>,
   colorScheme?: ColorScheme,
   i18n: {
     locale: Locale,

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -210,7 +210,7 @@ export type ColorScheme = 'dark' | 'light' | 'auto';
 // This is the type expected by ThemeContextProvider theme prop.
 // This config is provided by the user of the lib
 export type ThemeConfig = {
-    skin: Skin;
+    skin: Readonly<Skin>;
     colorScheme?: ColorScheme; // light by default. TODO: Change to auto by default in next major version
     i18n: {
         locale: Locale;


### PR DESCRIPTION
without this change, I have this kind of errors in flow:
![image](https://user-images.githubusercontent.com/1849576/162020147-22c5c50f-758b-4efa-8410-5704c2f3c941.png)

This is the explanation of the error:
https://flow.org/en/docs/faq/#toc-why-can-t-i-pass-a-string-to-a-function-that-takes-a-string-number