### PR TITLE
feat(Image,Video): use original proportion when setting `aspetRatio={0}`

### DIFF
--- a/flow-defs/image.js.flow
+++ b/flow-defs/image.js.flow
@@ -19,7 +19,7 @@ export type ImageProps = {
  width?: string | number,
  height?: string | number,
  /**
-  * defaults to 1:1, if both width and height are given, aspectRatio is ignored
+  * defaults to 1:1, if both width and height are given, aspectRatio is ignored. To use original image proportions, set aspectRatio to 0
   */
  aspectRatio?: AspectRatio | number,
  /**

--- a/flow-defs/video.js.flow
+++ b/flow-defs/video.js.flow
@@ -20,7 +20,7 @@ export type VideoProps = {
  width?: string | number,
  height?: string | number,
  /**
-  * defaults to 1:1, if both width and height are given, aspectRatio is ignored
+  * defaults to 1:1, if both width and height are given, aspectRatio is ignored. To use original video proportions, set aspectRatio to 0
   */
  aspectRatio?: AspectRatio | number,
  /**

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -23,12 +23,13 @@ const useStyles = createUseStyles(() => ({
         objectFit: 'cover',
         maxWidth: '100%',
         maxHeight: '100%',
+        borderRadius: ({noBorderRadius}) => (noBorderRadius ? 0 : 4),
 
         '@supports (aspect-ratio: 1 / 1)': {
-            borderRadius: ({noBorderRadius}) => (noBorderRadius ? 0 : 4),
             aspectRatio: ({aspectRatio}) => aspectRatio ?? 'unset',
         },
         '$wrapper &': {
+            borderRadius: 0, // the wrapper sets the border radius
             position: 'absolute',
             width: '100%',
             height: '100%',

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -68,7 +68,7 @@ export type ImageProps = {
     /** defaults to 100% when no width and no height are given */
     width?: string | number;
     height?: string | number;
-    /** defaults to 1:1, if both width and height are given, aspectRatio is ignored */
+    /** defaults to 1:1, if both width and height are given, aspectRatio is ignored. To use original image proportions, set aspectRatio to 0  */
     aspectRatio?: AspectRatio | number;
     /** defaults to empty string */
     alt?: string;
@@ -83,9 +83,11 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>(
         const noBorderRadiusContext = useDisableBorderRadius();
         const noBorderSetting = noBorderRadius ?? noBorderRadiusContext;
 
-        // if width or height are numeric, we can calculate the other with the ratio without css
-        const withCssAspectRatio = typeof props.width !== 'number' && typeof props.height !== 'number';
         const ratio = typeof aspectRatio === 'number' ? aspectRatio : RATIO[aspectRatio];
+        // if width or height are numeric, we can calculate the other with the ratio without css.
+        // if aspect ratio is 0, we use the original image proportions
+        const withCssAspectRatio =
+            typeof props.width !== 'number' && typeof props.height !== 'number' && ratio !== 0;
 
         const classes = useStyles({
             noBorderRadius: noBorderSetting,

--- a/src/video.tsx
+++ b/src/video.tsx
@@ -66,7 +66,7 @@ export type VideoProps = {
     /** defaults to 100% when no width and no height are given */
     width?: string | number;
     height?: string | number;
-    /** defaults to 1:1, if both width and height are given, aspectRatio is ignored */
+    /** defaults to 1:1, if both width and height are given, aspectRatio is ignored. To use original video proportions, set aspectRatio to 0 */
     aspectRatio?: AspectRatio | number;
     /** accepts multiple sources */
     src: string | Array<string> | VideoSource | Array<VideoSource>;
@@ -101,9 +101,11 @@ const Video = React.forwardRef<HTMLVideoElement, VideoProps>(
         const supportsAspectRatio = useSupportsAspectRatio();
         const noBorderRadius = useDisableBorderRadius();
 
-        // if width or height are numeric, we can calculate the other with the ratio without css
-        const withCssAspectRatio = typeof props.width !== 'number' && typeof props.height !== 'number';
         const ratio = typeof aspectRatio === 'number' ? aspectRatio : RATIO[aspectRatio];
+        // if width or height are numeric, we can calculate the other with the ratio without css
+        // if aspect ratio is 0, we use the original video proportions
+        const withCssAspectRatio =
+            typeof props.width !== 'number' && typeof props.height !== 'number' && ratio !== 0;
 
         const classes = useStyles({
             noBorderRadius,

--- a/src/video.tsx
+++ b/src/video.tsx
@@ -22,12 +22,13 @@ const useStyles = createUseStyles(() => ({
         objectFit: 'cover',
         maxWidth: '100%',
         maxHeight: '100%',
+        borderRadius: ({noBorderRadius}) => (noBorderRadius ? 0 : 4),
 
         '@supports (aspect-ratio: 1 / 1)': {
-            borderRadius: ({noBorderRadius}) => (noBorderRadius ? 0 : 4),
             aspectRatio: ({aspectRatio}) => aspectRatio ?? 'unset',
         },
         '$wrapper &': {
+            borderRadius: 0, // the wrapper sets the border radius
             position: 'absolute',
             width: '100%',
             height: '100%',


### PR DESCRIPTION
[TGT-777 ](https://jira.tid.es/browse/TGT-777)