### PR TITLE
fix(Text): inherit word-break style from parent when the wordBreak prop is not set

### DIFF
--- a/src/text.tsx
+++ b/src/text.tsx
@@ -41,7 +41,7 @@ const useStyles = createUseStyles((theme) => {
             letterSpacing: ({letterSpacing}) => letterSpacing,
             overflowWrap: ({wordBreak}) => (wordBreak ? 'anywhere' : 'inherit'),
             '@supports not (overflow-wrap: anywhere)': {
-                wordBreak: ({wordBreak}) => (wordBreak ? 'break-all' : 'normal'),
+                wordBreak: ({wordBreak}) => (wordBreak ? 'break-all' : 'inherit'),
             },
             // Needed to reset the default browser margin that adds to p, h1, h2... elements.
             margin: 0,


### PR DESCRIPTION
In a recent change in Text to fix a word break bug in old browsers, we set the wordBreak style to `'normal'` when the prop was not specified explicitly. But we had some code in webapp that relied in the old behavior of inheriting wordBreak style from parent dom elements. This PR reverts that to the previous behavior.

More info in this thread: https://teams.microsoft.com/l/message/19:4fc0c9a0eec140e3befc341e7271e9c2@thread.skype/1655215140563?tenantId=9744600e-3e04-492e-baa1-25ec245c6f10&groupId=bef9be07-03e4-4afb-8a79-f720a63e4c28&parentMessageId=1655215140563&teamName=Novum&channelName=Checkout-QSys&createdTime=1655215140563

Webapp code relying on style cascade:
https://github.com/Telefonica/webapp/blob/master/web/src/pages/payment-barcode/components/pay-now.js#L113-L117

The right fix should also include a change in webapp to stop relying in style inheritance.