### PR TITLE
fix(Checkbox): fix junk pixel in checkbox

### DIFF
--- a/src/checkbox.tsx
+++ b/src/checkbox.tsx
@@ -27,7 +27,7 @@ const useIconCheckboxStyles = createUseStyles(({colors, isIos}) => ({
         transition: 'box-shadow 0.3s',
     },
     boxChecked: {
-        boxShadow: `inset 0 0 0 9px ${colors.controlActivated}`,
+        boxShadow: `inset 0 0 0 12px ${colors.controlActivated}`,
     },
     check: {
         display: 'block',

--- a/src/checkbox.tsx
+++ b/src/checkbox.tsx
@@ -19,6 +19,7 @@ const useIconCheckboxStyles = createUseStyles(({colors, isIos}) => ({
         justifyContent: 'center',
         alignItems: 'center',
         userSelect: 'none',
+        outline: '1px solid transparent',
         borderRadius: 2,
         verticalAlign: 'middle',
         background: colors.background,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6722153/186263390-7195fc0c-e609-410a-bb85-fde72964a4b7.png) ![image](https://user-images.githubusercontent.com/6722153/186264453-089b1a81-4900-4805-8e88-bb95dbea3b4c.png)

https://user-images.githubusercontent.com/6722153/186265151-24a70077-0b16-4fed-89b3-9c460ded06b5.mov

When you enable and disable the checkbox a junk pixel appears

Apparently only in chrome

https://stackoverflow.com/questions/9983520/webkit-animation-is-leaving-junk-pixels-behind-on-the-screen