### PR TITLE
fix(Skin): improve control constant in dark mode in Blau & Telefónica

### DIFF
--- a/src/skins/blau.tsx
+++ b/src/skins/blau.tsx
@@ -215,7 +215,7 @@ export const getBlauSkin: GetKnownSkin = () => {
             textLinkInverse: palette.blauPurple30,
 
             // CONTROLS
-            control: palette.darkModeGrey,
+            control: palette.darkModeGrey6,
             loadingBar: palette.blauBluePrimary,
             loadingBarBackground: palette.darkModeGrey,
 

--- a/src/skins/telefonica.tsx
+++ b/src/skins/telefonica.tsx
@@ -201,7 +201,7 @@ export const getTelefonicaSkin: GetKnownSkin = () => {
             textButtonSecondaryInverseSelected: palette.grey4,
             textLink: palette.telefonicaBlue,
             textLinkInverse: palette.telefonicaBlue,
-            control: palette.darkModeGrey,
+            control: palette.darkModeGrey6,
             controlActivated: palette.telefonicaBlue,
             loadingBar: palette.telefonicaBlue,
             loadingBarBackground: applyAlpha(palette.white, 0.05),


### PR DESCRIPTION
https://github.com/Telefonica/mistica-design/issues/681

There is not exist test for dark mode colors, should be?