### PR TITLE
Dark mode image and video filter

### DIFF
--- a/src/image.tsx
+++ b/src/image.tsx
@@ -17,12 +17,13 @@ export const DisableBorderRadiusProvider: React.FC = ({children}) => (
     <DisableBorderRadiusContext.Provider value>{children}</DisableBorderRadiusContext.Provider>
 );
 
-const useStyles = createUseStyles(() => ({
+const useStyles = createUseStyles(({isDarkMode}) => ({
     image: {
         display: 'block',
         objectFit: 'cover',
         maxWidth: '100%',
         maxHeight: '100%',
+        filter: isDarkMode ? 'brightness(.8) contrast(1.2)' : 'none',
         borderRadius: ({noBorderRadius}) => (noBorderRadius ? 0 : 8),
 
         '@supports (aspect-ratio: 1 / 1)': {

--- a/src/video.tsx
+++ b/src/video.tsx
@@ -37,7 +37,7 @@ const useStyles = createUseStyles(({isDarkMode}) => ({
             top: 0,
             left: 0,
         },
-        filter: isDarkMode ? 'brightness(.8) contrast(1.2)' : 'none',
+        filter: isDarkMode ? 'brightness(.8) contrast(1.05)' : 'none',
     },
     wrapper: {
         overflow: 'hidden',

--- a/src/video.tsx
+++ b/src/video.tsx
@@ -17,7 +17,7 @@ export const RATIO = {
     '4:3': 4 / 3,
 };
 
-const useStyles = createUseStyles(() => ({
+const useStyles = createUseStyles(({isDarkMode}) => ({
     video: {
         background: 'transparent',
         display: 'block',
@@ -37,6 +37,7 @@ const useStyles = createUseStyles(() => ({
             top: 0,
             left: 0,
         },
+        filter: isDarkMode ? 'brightness(.8) contrast(1.2)' : 'none',
     },
     wrapper: {
         overflow: 'hidden',


### PR DESCRIPTION
An example
(video) brightness(.8) contrast(1.2) → https://ibit.ly/ZB_5
(video) brightness(.8) contrast(1.05) → https://ibit.ly/PkiF

reference: https://css-tricks.com/a-complete-guide-to-dark-mode-on-the-web/#aa-dark-mode-images