### PR TITLE
fix(playroom): PreviewTools tabs in desktop

### DIFF
--- a/playroom/components.tsx
+++ b/playroom/components.tsx
@@ -48,8 +48,7 @@ const useControlsStyles = createUseStyles((theme) => ({
         height: 57,
     },
     tabs: {
-        flexBasis: '100%',
-        marginRight: 150,
+        flexBasis: '73%',
         whiteSpace: 'nowrap',
     },
     desktopControlItem: {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6722153/200573824-5cacb8aa-7e54-4213-8e8d-66e300d9b003.png)
