### PR TITLE
fix(useId): support React 17

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -101,19 +101,20 @@ export const useElementDimensions = (): {
     return {width, height, ref};
 };
 
-const useAriaIdReact18 = (id?: string): string => {
-    const reactId = React.useId();
-    return id || reactId;
+export const useAriaId = (id?: string): string => {
+    const {useId} = useTheme();
+    // This useId should be stable, so the rules-of-hooks still apply
+    if (useId) {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const generatedId = useId();
+        return id || generatedId;
+    } else {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const getAriaId = React.useContext(AriaIdGetterContext);
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        return React.useRef(id || getAriaId()).current;
+    }
 };
-
-const isUseIdAvailable = React.useId !== undefined;
-
-export const useAriaId = isUseIdAvailable
-    ? useAriaIdReact18
-    : (id?: string): string => {
-          const getAriaId = React.useContext(AriaIdGetterContext);
-          return React.useRef(id || getAriaId()).current;
-      };
 
 export const useWindowSize = (): {
     height: number;

--- a/src/theme-context-provider.tsx
+++ b/src/theme-context-provider.tsx
@@ -118,6 +118,7 @@ const ThemeContextProvider: React.FC<Props> = ({theme, children, as}) => {
             isDarkMode: isDarkModeEnabled,
             isIos: getPlatform(platformOverrides) === 'ios',
             useHrefDecorator: theme.useHrefDecorator ?? useDefaultHrefDecorator,
+            useId: theme.useId,
         };
     }, [theme, isDarkModeEnabled]);
 

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -227,6 +227,7 @@ export type ThemeConfig = Readonly<{
     dimensions?: Readonly<{headerMobileHeight: number | 'mistica'}>;
     Link?: LinkComponent;
     useHrefDecorator?: () => (href: string) => string;
+    useId?: () => string;
     enableTabFocus?: boolean;
 }>;
 
@@ -254,4 +255,5 @@ export type Theme = {
     isDarkMode: boolean;
     isIos: boolean;
     useHrefDecorator: () => (href: string) => string;
+    useId?: () => string;
 };


### PR DESCRIPTION
We was trying to use `React.useId` conditionally to support React 17 and 18, but this doesn't seem to work:
![image](https://user-images.githubusercontent.com/1849576/216976952-ce44b3af-6bb4-4f9b-bb2e-416b90ef6704.png)

This is a workaround that will allow mistica to work in React 17. React 18 users can inject `useId` if they prefer to use it instead of the builtin solution:

`<ThemeContextProvider theme={{...restOfTheTheme, useId: React.useId}}>`