### PR TITLE
feat(Card): add hypenation to all cards

### DIFF
--- a/src/card.tsx
+++ b/src/card.tsx
@@ -202,7 +202,7 @@ const CardContent: React.FC<CardContentProps> = ({
                                 {renderHeadline()}
                                 <Stack space={4}>
                                     {pretitle && (
-                                        <Text2 truncate={pretitleLinesMax} as="div" regular>
+                                        <Text2 truncate={pretitleLinesMax} as="div" regular hyphens="auto">
                                             {pretitle}
                                         </Text2>
                                     )}
@@ -214,10 +214,11 @@ const CardContent: React.FC<CardContentProps> = ({
                                         truncate={titleLinesMax}
                                         weight={textPresets.cardTitle.weight}
                                         as="h3"
+                                        hyphens="auto"
                                     >
                                         {title}
                                     </Text>
-                                    <Text2 truncate={subtitleLinesMax} as="div" regular>
+                                    <Text2 truncate={subtitleLinesMax} as="div" regular hyphens="auto">
                                         {subtitle}
                                     </Text2>
                                 </Stack>
@@ -231,6 +232,7 @@ const CardContent: React.FC<CardContentProps> = ({
                             as="p"
                             regular
                             color={vars.colors.textSecondary}
+                            hyphens="auto"
                         >
                             {description}
                         </Text2>
@@ -513,7 +515,7 @@ export const SnapCard = React.forwardRef<HTMLDivElement, SnapCardProps>(
                             {icon && <Box paddingBottom={16}>{icon}</Box>}
                             <Stack space={4}>
                                 {title && (
-                                    <Text2 truncate={titleLinesMax} as="h3" regular>
+                                    <Text2 truncate={titleLinesMax} as="h3" regular hyphens="auto">
                                         {title}
                                     </Text2>
                                 )}
@@ -523,6 +525,7 @@ export const SnapCard = React.forwardRef<HTMLDivElement, SnapCardProps>(
                                         regular
                                         color={vars.colors.textSecondary}
                                         as="p"
+                                        hyphens="auto"
                                     >
                                         {subtitle}
                                     </Text2>
@@ -661,6 +664,7 @@ const DisplayCard = React.forwardRef<HTMLDivElement, GenericDisplayCardProps>(
                                                                 as="div"
                                                                 regular
                                                                 textShadow={textShadow}
+                                                                hyphens="auto"
                                                             >
                                                                 {pretitle}
                                                             </Text2>
@@ -670,6 +674,7 @@ const DisplayCard = React.forwardRef<HTMLDivElement, GenericDisplayCardProps>(
                                                             truncate={titleLinesMax}
                                                             as="h3"
                                                             textShadow={textShadow}
+                                                            hyphens="auto"
                                                         >
                                                             {title}
                                                         </Text6>
@@ -686,6 +691,7 @@ const DisplayCard = React.forwardRef<HTMLDivElement, GenericDisplayCardProps>(
                                                 regular
                                                 color={vars.colors.textSecondary}
                                                 textShadow={textShadow}
+                                                hyphens="auto"
                                             >
                                                 {description}
                                             </Text3>
@@ -837,6 +843,7 @@ export const PosterCard = React.forwardRef<HTMLDivElement, PosterCardProps>(
                                                                 as="div"
                                                                 regular
                                                                 textShadow={textShadow}
+                                                                hyphens="auto"
                                                             >
                                                                 {pretitle}
                                                             </Text2>
@@ -849,6 +856,7 @@ export const PosterCard = React.forwardRef<HTMLDivElement, PosterCardProps>(
                                                             truncate={titleLinesMax}
                                                             weight={textPresets.cardTitle.weight}
                                                             as="h3"
+                                                            hyphens="auto"
                                                         >
                                                             {title}
                                                         </Text>
@@ -863,6 +871,7 @@ export const PosterCard = React.forwardRef<HTMLDivElement, PosterCardProps>(
                                                 as="p"
                                                 regular
                                                 textShadow={textShadow}
+                                                hyphens="auto"
                                             >
                                                 {description}
                                             </Text2>

--- a/src/highlighted-card.tsx
+++ b/src/highlighted-card.tsx
@@ -93,6 +93,7 @@ const Content = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
                     truncate={props.titleLinesMax}
                     weight={textPresets.cardTitle.weight}
                     as="h3"
+                    hyphens="auto"
                 >
                     {title}
                 </Text>
@@ -102,6 +103,7 @@ const Content = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
                         color={vars.colors.textSecondary}
                         truncate={props.descriptionLinesMax}
                         as="p"
+                        hyphens="auto"
                     >
                         {description}
                     </Text2>


### PR DESCRIPTION
As discussed in [this issue](https://github.com/Telefonica/mistica-design/issues/932), adding `hypen="auto"` to every text field for every card:
- Data
- Display Data
- Display Media
- Highlighted
- Media
- Poster
- Snap

![Data card](https://user-images.githubusercontent.com/25785151/232028825-a43b56fe-b1da-40fe-827e-245cc0c02282.png) ![Display Data card](https://user-images.githubusercontent.com/25785151/232028830-d19016d5-784b-4ac9-9cd5-c0c4984f7223.png) ![Display Media card](https://user-images.githubusercontent.com/25785151/232028832-c57935a2-571a-4dbb-b7b0-2ebcbe281e31.png) ![Highlighted card](https://user-images.githubusercontent.com/25785151/232028833-ccbc2855-572d-4670-be29-420bd3a01dc2.png) ![Media card](https://user-images.githubusercontent.com/25785151/232028837-af4dbdb1-021b-444f-8087-232e90b485ba.png) ![Poster card](https://user-images.githubusercontent.com/25785151/232028839-7f670620-cb36-4135-a283-ab67e0ad4288.png) ![Snap card](https://user-images.githubusercontent.com/25785151/232028841-17f0cb9e-9633-442a-86b3-457a37d25ee4.png)
