### PR TITLE
fix(DateTimePicker): fix locale imports in date-time-picker

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -1,5 +1,6 @@
 module.exports = {
     ...require('./jest.base.config'),
+    testTimeout: 10000,
     displayName: 'unit',
     testEnvironment: 'jsdom',
     testMatch: ['**/__tests__/*-test.tsx'],

--- a/src/__tests__/button-test.tsx
+++ b/src/__tests__/button-test.tsx
@@ -89,6 +89,7 @@ test('buttons can track events', async () => {
 });
 
 test('buttons track default events', async () => {
+    jest.setTimeout(10000);
     const logEventSpy = jest.fn();
 
     render(

--- a/src/__tests__/button-test.tsx
+++ b/src/__tests__/button-test.tsx
@@ -89,7 +89,6 @@ test('buttons can track events', async () => {
 });
 
 test('buttons track default events', async () => {
-    jest.setTimeout(10000);
     const logEventSpy = jest.fn();
 
     render(

--- a/src/date-time-picker.tsx
+++ b/src/date-time-picker.tsx
@@ -1,3 +1,9 @@
+/**
+ * Do not use this component!
+ * Use DateField or FormDateTimeField
+ *
+ * This component is a fallback for browsers that don't support datetime-local or date inputs
+ */
 import * as React from 'react';
 import {TextFieldBaseAutosuggest} from './text-field-base';
 import IconCalendarRegular from './generated/mistica-icons/icon-calendar-regular';
@@ -10,19 +16,14 @@ import {useElementDimensions, useTheme} from './hooks';
 import IconCloseRegular from './generated/mistica-icons/icon-close-regular';
 import * as styles from './date-time-picker.css';
 import {vars} from './skins/skin-contract.css';
+import 'moment/locale/es';
+import 'moment/locale/de';
+import 'moment/locale/pt-br';
+import 'moment/locale/en-gb';
 
 import type {CommonFormFieldProps} from './text-field-base';
 import type Moment from 'moment';
-
-/**
- * Do not use this component!
- * Use DateField or FormDateTimeField
- *
- * This component is a fallback for browsers that don't support datetime-local or date inputs
- */
-
-const browserLocale = navigator.language.toLocaleLowerCase().split('-')[0];
-import(/* webpackChunkName: "moment-locale" */ `moment/locale/${browserLocale}`).finally(() => {});
+import type {Locale} from './utils/locale';
 
 export interface DateTimePickerProps extends CommonFormFieldProps {
     inputRef: (field: HTMLInputElement | null) => void;
@@ -31,9 +32,27 @@ export interface DateTimePickerProps extends CommonFormFieldProps {
     mode?: 'year-month';
 }
 
+const langToLocale: Record<string, string> = {
+    es: 'es', // spanish
+    ca: 'es', // catalan
+    eu: 'es', // euskera
+    gl: 'es', // gallego
+    de: 'de', // german
+    pt: 'pt-br', // portuguese
+    en: 'en-gb', // english
+};
+
+const getLocaleForMoment = (locale: Locale) => {
+    const lang = locale.toLocaleLowerCase().split('-')[0];
+    return langToLocale[lang] || 'en-gb';
+};
+
 const DateTimePicker: React.FC<DateTimePickerProps> = ({withTime, mode, isValidDate, optional, ...rest}) => {
     const [showPicker, realSetShowPicker] = React.useState(false);
-    const {texts} = useTheme();
+    const {
+        texts,
+        i18n: {locale},
+    } = useTheme();
     const fieldRef = React.useRef<HTMLInputElement | null>(null);
     const {height: pickerContainerHeight, ref: pickerContainerRef} = useElementDimensions();
 
@@ -149,7 +168,7 @@ const DateTimePicker: React.FC<DateTimePickerProps> = ({withTime, mode, isValidD
                             dateFormat={mode === 'year-month' ? 'YYYY-MM' : undefined}
                             timeFormat={withTime ? 'HH:mm' : false}
                             initialValue={getValue()}
-                            locale={browserLocale}
+                            locale={getLocaleForMoment(locale)}
                             input={false}
                             onChange={setValue}
                             isValidDate={isValidDate}


### PR DESCRIPTION
Fixes the following warning:

```text
- warn ./node_modules/@telefonica/mistica/dist/date-time-picker.js
Critical dependency: the request of a dependency is an expression

Import trace for requested module:
./node_modules/@telefonica/mistica/dist/date-time-picker.js
./node_modules/@telefonica/mistica/dist/date-field.js
./node_modules/@telefonica/mistica/dist/index.js
./app/page.tsx
```

Verified using the `hello-world-web` application. Copying the dist folder of the fixed mistica (and deleting `.next/cache`), this warning dissapears.