### PR TITLE
fix(AdvancedDataCard): avoid content overflow with top actions

### DIFF
--- a/src/community/advanced-data-card.css.ts
+++ b/src/community/advanced-data-card.css.ts
@@ -52,14 +52,14 @@ export const touchableContainer = style([
 export const hoverEffect = style({
     '@media': {
         [mq.supportsHover]: {
+            transition: 'background-color 0.1s ease-in-out',
+
             selectors: {
                 '&:hover': {
                     backgroundColor: vars.colors.backgroundContainerHover,
-                    transition: '0.15s ease-in-out',
                 },
                 '&:active': {
                     backgroundColor: vars.colors.backgroundContainerPressed,
-                    transition: '0.1s ease-in-out',
                 },
             },
         },

--- a/src/community/advanced-data-card.tsx
+++ b/src/community/advanced-data-card.tsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
 import {CardActionsGroup} from '../card';
 import {useTheme} from '../hooks';
 import {getPrefixedDataAttributes} from '../utils/dom';
+import Inline from '../inline';
 
 import type {CardAction} from '../card';
 import type StackingGroup from '../stacking-group';
@@ -29,6 +30,8 @@ import type {
     SimpleBlock,
     ValueBlock,
 } from './blocks';
+
+const TOP_ACTION_BUTTON_SIZE = 48;
 
 type CardContentProps = {
     headline?: string | RendersNullableElement<typeof Tag>;
@@ -265,6 +268,13 @@ export const AdvancedDataCard = React.forwardRef<HTMLDivElement, AdvancedDataCar
         const hasFooter = !!button || !!footerImage || !!footerText || !!buttonLink;
         const hasExtras = !!extra?.length;
 
+        const topActionsCount = (actions?.length || 0) + (onClose ? 1 : 0);
+        const topActionsStylesWithoutIcon = {
+            marginRight: -16,
+            marginTop: -24,
+            width: TOP_ACTION_BUTTON_SIZE * topActionsCount,
+        } as const;
+
         return (
             <section
                 className={sprinkles({
@@ -289,22 +299,25 @@ export const AdvancedDataCard = React.forwardRef<HTMLDivElement, AdvancedDataCar
                             )}
                         >
                             <Box paddingTop={8}>
-                                <Stack space={8}>
-                                    {stackingGroup}
-                                    <CardContent
-                                        headline={headline}
-                                        pretitle={pretitle}
-                                        pretitleAs={pretitleAs}
-                                        pretitleLinesMax={pretitleLinesMax}
-                                        title={title}
-                                        titleAs={titleAs}
-                                        titleLinesMax={titleLinesMax}
-                                        subtitle={subtitle}
-                                        subtitleLinesMax={subtitleLinesMax}
-                                        description={description}
-                                        descriptionLinesMax={descriptionLinesMax}
-                                    />
-                                </Stack>
+                                <Inline space={0}>
+                                    <Stack space={8}>
+                                        {stackingGroup}
+                                        <CardContent
+                                            headline={headline}
+                                            pretitle={pretitle}
+                                            pretitleAs={pretitleAs}
+                                            pretitleLinesMax={pretitleLinesMax}
+                                            title={title}
+                                            titleAs={titleAs}
+                                            titleLinesMax={titleLinesMax}
+                                            subtitle={subtitle}
+                                            subtitleLinesMax={subtitleLinesMax}
+                                            description={description}
+                                            descriptionLinesMax={descriptionLinesMax}
+                                        />
+                                    </Stack>
+                                    {!stackingGroup && <div style={topActionsStylesWithoutIcon} />}
+                                </Inline>
                             </Box>
                         </div>
                         <div style={{flexGrow: 1}} />


### PR DESCRIPTION
Issue: [Link](https://jira.tid.es/browse/WEB-1495)

Using the same approach as with DataCard: if no stackingGroup is provided, we force the content's width in order to avoid overlap with the top actions.