### PR TITLE
chore(PreviewTools): update height in desktop to avoid double border at bottom

### DIFF
--- a/playroom/components/index.tsx
+++ b/playroom/components/index.tsx
@@ -338,7 +338,7 @@ export const PreviewTools = ({
         return (
             <>
                 {controls}
-                <div style={{height: 56}} />
+                <div className={styles.controlsHeight} />
                 {children}
             </>
         );

--- a/playroom/components/index.tsx
+++ b/playroom/components/index.tsx
@@ -171,7 +171,7 @@ const PreviewToolsControls: React.FC<PreviewToolsControlsProps> = ({
         );
     } else {
         return (
-            <div className={`${styles.controls} ${styles.desktopControls}`}>
+            <div className={styles.controls}>
                 <div className={styles.tabs}>
                     <Tabs
                         tabs={Object.values(themesMap).map(({icon}) => ({text: '', icon}))}

--- a/playroom/preview-tools.css.ts
+++ b/playroom/preview-tools.css.ts
@@ -15,18 +15,19 @@ export const controls = style([
         gap: 16,
         zIndex: 2,
         background: 'white',
+        borderBottom: `1px solid ${skinVars.colors.divider}`,
+        height: 57,
+        '@media': {
+            [mq.desktopOrBigger]: {
+                height: 59,
+            },
+        },
     },
 ]);
 
 globalStyle(`${controls} *`, {outline: 'none'});
 
 export const flexSpacer = sprinkles({flex: 1});
-
-export const desktopControls = style({
-    borderBottom: `1px solid ${skinVars.colors.divider}`,
-    height: 57,
-    paddingRight: 16,
-});
 
 export const tabs = style({
     flexBasis: '73%',

--- a/playroom/preview-tools.css.ts
+++ b/playroom/preview-tools.css.ts
@@ -2,6 +2,15 @@ import {globalStyle, style} from '@vanilla-extract/css';
 import {mq, skinVars} from '../src';
 import {sprinkles} from '../src/sprinkles.css';
 
+export const controlsHeight = style({
+    height: 57,
+    '@media': {
+        [mq.desktopOrBigger]: {
+            height: 59,
+        },
+    },
+});
+
 export const controls = style([
     sprinkles({
         position: 'fixed',
@@ -16,13 +25,8 @@ export const controls = style([
         zIndex: 2,
         background: 'white',
         borderBottom: `1px solid ${skinVars.colors.divider}`,
-        height: 57,
-        '@media': {
-            [mq.desktopOrBigger]: {
-                height: 59,
-            },
-        },
     },
+    controlsHeight,
 ]);
 
 globalStyle(`${controls} *`, {outline: 'none'});


### PR DESCRIPTION
PreviewTools renders a border at the bottom of the tabs. After merging changes in Tabs, this border was not looking good in desktop:

![image](https://github.com/Telefonica/mistica-web/assets/25785151/a18bb55f-253b-47b9-ba53-7d0f3b71ad03)
