### PR TITLE
fix(ButtonLink): add aligned prop back until next major release

### DIFF
--- a/src/button.tsx
+++ b/src/button.tsx
@@ -515,7 +515,7 @@ export const ButtonLink = React.forwardRef<TouchableElement, ButtonLinkProps>((p
     const commonProps = {
         className: classnames(styles.link, {
             [styles.inverseLink]: isInverse,
-            [styles.alignedLeftLink]: !!props.bleedLeft,
+            [styles.alignedLeftLink]: !!props.bleedLeft || !!props.aligned,
             [styles.alignedRightLink]: !!props.bleedRight,
             [styles.alignedVerticalLink]: !!props.bleedY,
             [styles.isLoading]: showSpinner,


### PR DESCRIPTION
When we deprecated aligned prop in ButtonLink, we removed its logic from the component. This should be done during next major release, not now, so this PR introduces it back temporarily