### PR TITLE
fix(Community): export community components with namespace

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -204,9 +204,11 @@ if (process.env.NODE_ENV !== 'production' && isClientSide()) {
     }
 }
 
-// Temporary solution to export Community components until mistica gets migrated to ESModules
-// the community.js export has issues because it exports an ES module and next12 interterprets it as a CommonJS module
-// importing from /dist/ is not an option because those modules don't get the context from the theme provider
+/*
+ * Temporary solution to export Community components until Mistica gets migrated to ESModules
+ * the community.js export has issues because it exports an ES module and next12 interterprets it as a CommonJS module
+ * importing from /dist/ is not an option because those modules don't get the context from the theme provider
+ */
 export {default as CommunityExampleComponent} from './community/example-component';
 export {default as CommunityAdvancedDataCard} from './community/advanced-data-card';
 export {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -204,6 +204,20 @@ if (process.env.NODE_ENV !== 'production' && isClientSide()) {
     }
 }
 
+// Temporary solution to export Community components until mistica gets migrated to ESModules
+// the community.js export has issues because it exports an ES module and next12 interterprets it as a CommonJS module
+// importing from /dist/ is not an option because those modules don't get the context from the theme provider
+export {default as CommunityExampleComponent} from './community/example-component';
+export {default as CommunityAdvancedDataCard} from './community/advanced-data-card';
+export {
+    RowBlock as CommunityRowBlock,
+    SimpleBlock as CommunitySimpleBlock,
+    InformationBlock as CommunityInformationBlock,
+    HighlightedValueBlock as CommunityHighlightedValueBlock,
+    ValueBlock as CommunityValueBlock,
+    ProgressBlock as CommunityProgressBlock,
+} from './community/blocks';
+
 // Exported this way to facilitate tree-shaking
 export {default as Icon2GFilled} from './generated/mistica-icons/icon-2-g-filled';
 export {default as Icon2GRegular} from './generated/mistica-icons/icon-2-g-regular';


### PR DESCRIPTION
This workarounds issues with next12 and commonjs modules. Components imported from from community.js are not able to access the Theme context, and community.js internally uses ES imports which causes problems in next build.

Consider this a temporary workaround that will be removed in the next mistica major.