### PR TITLE
fix(Tabs): remove extra margin in safari

### DIFF
--- a/src/__stories__/image-story.tsx
+++ b/src/__stories__/image-story.tsx
@@ -74,9 +74,10 @@ export const Default: StoryComponent<Args> = ({
      * */
     const error = <Image src="data:image/jpg;" {...props} />;
 
-    /** for some reason, if we write this logic with a conditional (isInvalidSource ? error : image),
+    /**
+     * For some reason, if we write this logic with a conditional (isInvalidSource ? error : image),
      * the image element triggers an error when switching the isInvalidSource control from true to false
-     * */
+     */
     return (
         <>
             {!isInvalidSource && image}

--- a/src/tabs.css.ts
+++ b/src/tabs.css.ts
@@ -55,6 +55,10 @@ const baseTab = style([
         background: 'transparent',
     }),
     {
+        /** Setting margin to 0, in order to avoid Safari from automatically adding extra margin to
+         * the touchable container (https://stackoverflow.com/a/71093016)
+         */
+        margin: 0,
         textAlign: 'center',
         verticalAlign: 'baseline',
         borderBottom: '2px solid transparent',

--- a/src/tabs.css.ts
+++ b/src/tabs.css.ts
@@ -55,7 +55,8 @@ const baseTab = style([
         background: 'transparent',
     }),
     {
-        /** Setting margin to 0, in order to avoid Safari from automatically adding extra margin to
+        /**
+         * Setting margin to 0, in order to avoid Safari from automatically adding extra margin to
          * the touchable container (https://stackoverflow.com/a/71093016)
          */
         margin: 0,


### PR DESCRIPTION
In Safari, buttons have extra padding/margin by default ([stack overflow post](https://stackoverflow.com/questions/5170041/button-extra-padding-problem-in-safari)). We need to remove this for tabs.

Issue: [Link](https://jira.tid.es/browse/WEB-1510)