### PR TITLE
fix(Form): set mountedRef value to true on client side first render

### DIFF
--- a/src/form.tsx
+++ b/src/form.tsx
@@ -48,6 +48,12 @@ const Form: React.FC<FormProps> = ({
     const id = useAriaId(idProp);
 
     React.useEffect(() => {
+        /**
+         * When using React with Strict Mode on, the components are rendered twice. If we don't set the ref's value to true
+         * every time the component is mounted, during the second mount this value will be equal to false, preventing handleSubmit()
+         * from resetting the formStatus to filling after the submit action is handled.
+         * https://stackoverflow.com/questions/60618844/react-hooks-useeffect-is-called-twice-even-if-an-empty-array-is-used-as-an-ar/60619061#60619061
+         */
         isMountedRef.current = true;
         return () => {
             isMountedRef.current = false;

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -47,12 +47,12 @@ const Form: React.FC<FormProps> = ({
     const {texts} = useTheme();
     const id = useAriaId(idProp);
 
-    React.useEffect(
-        () => () => {
+    React.useEffect(() => {
+        isMountedRef.current = true;
+        return () => {
             isMountedRef.current = false;
-        },
-        []
-    );
+        };
+    }, []);
 
     const register = React.useCallback(
         (name: string, {input, validator, focusableElement}: FieldRegistration) => {

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -49,8 +49,8 @@ const Form: React.FC<FormProps> = ({
 
     React.useEffect(() => {
         /**
-         * When using React with Strict Mode on, the components are rendered twice. If we don't set the ref's value to true
-         * every time the component is mounted, during the second mount this value will be equal to false, preventing handleSubmit()
+         * When using React with Strict Mode on, the component's effects are executed twice. If we don't set the ref's value to true
+         * the first time the effect is triggered, this value will be set to false forever, preventing handleSubmit()
          * from resetting the formStatus to filling after the submit action is handled.
          * https://stackoverflow.com/questions/60618844/react-hooks-useeffect-is-called-twice-even-if-an-empty-array-is-used-as-an-ar/60619061#60619061
          */

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -52,7 +52,7 @@ const Form: React.FC<FormProps> = ({
          * When using React with Strict Mode on, the component's effects are executed twice. If we don't set the ref's value to true
          * the first time the effect is triggered, this value will be set to false forever, preventing handleSubmit()
          * from resetting the formStatus to filling after the submit action is handled.
-         * https://stackoverflow.com/questions/60618844/react-hooks-useeffect-is-called-twice-even-if-an-empty-array-is-used-as-an-ar/60619061#60619061
+         * https://react.dev/reference/react/StrictMode#strictmode
          */
         isMountedRef.current = true;
         return () => {


### PR DESCRIPTION
Solving issue reported [here](https://github.com/Telefonica/mistica-web/issues/842).

When using React with StrictMode on, in dev environment components' effects are executed twice (https://react.dev/reference/react/StrictMode#strictmode)

After mounting the component and executing the effects once, the `isMountedRef` value is set to false, but it's never reset to true in the second time the effect is triggered. This causes the form to never update its state to "filling" after performing a form submit:

![image](https://github.com/Telefonica/mistica-web/assets/25785151/f9654c41-2596-46c4-8161-2dfd370ddfa2)
