### PR TITLE
WEB-1430 fix Text SSR

### DIFF
--- a/src/__acceptance_tests__/__ssr_pages__/text.tsx
+++ b/src/__acceptance_tests__/__ssr_pages__/text.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {Stack, Text, Text1, Text10, Text2, Text3, Text4, Text5, Text6, Text7, Text8, Text9} from '../../..';
 
-const FormTest = (): JSX.Element => (
+const TextTest = (): JSX.Element => (
     <Stack space={8}>
         <Text>Text</Text>
         <Text1 regular>Text1</Text1>
@@ -17,4 +17,4 @@ const FormTest = (): JSX.Element => (
     </Stack>
 );
 
-export default FormTest;
+export default TextTest;

--- a/src/__acceptance_tests__/__ssr_pages__/text.tsx
+++ b/src/__acceptance_tests__/__ssr_pages__/text.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import {Stack, Text, Text1, Text10, Text2, Text3, Text4, Text5, Text6, Text7, Text8, Text9} from '../../..';
+
+const FormTest = (): JSX.Element => (
+    <Stack space={8}>
+        <Text>Text</Text>
+        <Text1 regular>Text1</Text1>
+        <Text2 regular>Text2</Text2>
+        <Text3 regular>Text3</Text3>
+        <Text4 regular>Text4</Text4>
+        <Text5>Text5</Text5>
+        <Text6>Text6</Text6>
+        <Text7>Text7</Text7>
+        <Text8>Text8</Text8>
+        <Text9>Text9</Text9>
+        <Text10>Text10</Text10>
+    </Stack>
+);
+
+export default FormTest;

--- a/src/__acceptance_tests__/text-ssr-acceptance-test.tsx
+++ b/src/__acceptance_tests__/text-ssr-acceptance-test.tsx
@@ -1,0 +1,5 @@
+import {openSSRPage} from '../test-utils';
+
+test('ssr text', async () => {
+    await openSSRPage({name: 'text'});
+});

--- a/src/text.tsx
+++ b/src/text.tsx
@@ -108,10 +108,10 @@ export const Text: React.FC<TextProps> = ({
     });
 
     const sizeVars = assignInlineVars({
-        [styles.vars.mobileSize]: mobileSize ? pxToRem(mobileSize) : '',
-        [styles.vars.mobileLineHeight]: mobileLineHeight ? pxToRem(mobileLineHeight) : '',
-        [styles.vars.desktopSize]: desktopSize ? pxToRem(desktopSize) : '',
-        [styles.vars.desktopLineHeight]: desktopLineHeight ? pxToRem(desktopLineHeight) : '',
+        [styles.vars.mobileSize]: mobileSize ? pxToRem(mobileSize) : 'inherit',
+        [styles.vars.mobileLineHeight]: mobileLineHeight ? pxToRem(mobileLineHeight) : 'inherit',
+        [styles.vars.desktopSize]: desktopSize ? pxToRem(desktopSize) : 'inherit',
+        [styles.vars.desktopLineHeight]: desktopLineHeight ? pxToRem(desktopLineHeight) : 'inherit',
     });
     const textVars = truncate
         ? assignInlineVars({


### PR DESCRIPTION
The empty string in conditional values inside `assignInlineVars` produced different styles in server and client