### PR TITLE
fix(Header): don't render title when not provided

### DIFF
--- a/src/__screenshot_tests__/stacking-group-screenshot-test.tsx
+++ b/src/__screenshot_tests__/stacking-group-screenshot-test.tsx
@@ -1,4 +1,4 @@
-import {openStoryPage, screen} from '../test-utils';
+import {openStoryPage, screen, ssimScreenshotConfig} from '../test-utils';
 
 test.each`
     type        | stacked  | inverse
@@ -20,5 +20,5 @@ test.each`
     const element = await screen.findByTestId('stacking-group');
     const image = await element.screenshot();
 
-    expect(image).toMatchImageSnapshot();
+    expect(image).toMatchImageSnapshot(ssimScreenshotConfig);
 });

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -94,7 +94,8 @@ export const Header: React.FC<HeaderProps> = ({
                 <Box paddingRight={16}>
                     <Stack space={8}>
                         {pretitle && renderRichText(pretitle, {color: vars.colors.textPrimary})}
-                        {small ? <Title2 as="h2">{title}</Title2> : <Title3 as="h2">{title}</Title3>}
+                        {title &&
+                            (small ? <Title2 as="h2">{title}</Title2> : <Title3 as="h2">{title}</Title3>)}
                         {description &&
                             (small ? (
                                 <Text2 regular color={vars.colors.textSecondary}>


### PR DESCRIPTION
This was broken because of this change:
https://github.com/Telefonica/mistica-web/pull/880/files#diff-e751a29b3f34d283e9d54e96a51d36af37fbbaa38f8fdb994b3e5fa920065ea2

This causes this issue in webapp:
![header-cards-single-screenshot-test-tsx-header-cards-single-brand-movistar-es-in-mobile-ios-with-skeleton-true-1-diff](https://github.com/Telefonica/mistica-web/assets/1849576/85b5fda1-8ad9-4e41-bfd3-19160b47bd0e)
