### PR TITLE
fix(reset.css): avoid iOS Safari to unexpectedly zoom some font sizes

### DIFF
--- a/css/reset.css
+++ b/css/reset.css
@@ -74,7 +74,7 @@ body {
     -moz-osx-font-smoothing: grayscale;
     font-family: -apple-system, 'Roboto', 'Helvetica', 'Arial', sans-serif;
 
-    // https://stackoverflow.com/questions/20924039/wrong-font-size-when-using-float-right-in-css-on-mobile-safari/22417120#22417120
+    /* https://stackoverflow.com/questions/20924039/wrong-font-size-when-using-float-right-in-css-on-mobile-safari/22417120#22417120 */
     text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
 }

--- a/css/reset.css
+++ b/css/reset.css
@@ -73,6 +73,10 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     font-family: -apple-system, 'Roboto', 'Helvetica', 'Arial', sans-serif;
+
+    // https://stackoverflow.com/questions/20924039/wrong-font-size-when-using-float-right-in-css-on-mobile-safari/22417120#22417120
+    text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
 }
 *,
 *:before,

--- a/src/text.css.ts
+++ b/src/text.css.ts
@@ -40,6 +40,8 @@ export const text = style({
     margin: 0, // Needed to reset the default browser margin that adds to p, h1, h2... elements.
     fontSize: desktopSize,
     lineHeight: desktopLineHeight,
+    textSizeAdjust: '100%',
+    WebkitTextSizeAdjust: '100%',
 
     '@media': {
         [mq.tabletOrSmaller]: {


### PR DESCRIPTION
https://jira.tid.es/browse/WEB-1578