### PR TITLE
fix(Menu, Accordion, LoadingBar, NavigationBar): disable react transition group timeout for screenshot tests

### DIFF
--- a/src/accordion.tsx
+++ b/src/accordion.tsx
@@ -13,6 +13,7 @@ import {Boxed} from './boxed';
 import {useIsInverseVariant} from './theme-variant-context';
 import {useAriaId} from './hooks';
 import {CSSTransition} from 'react-transition-group';
+import {isRunningAcceptanceTest} from './utils/platform';
 
 import type {ExclusifyUnion} from './utils/utility-types';
 import type {DataAttributes, TrackingEvent} from './utils/types';
@@ -173,7 +174,7 @@ const AccordionItemContent = React.forwardRef<TouchableElement, AccordionItemCon
                 </BaseTouchable>
                 <CSSTransition
                     in={isOpen}
-                    timeout={ACCORDION_TRANSITION_DURATION_IN_MS}
+                    timeout={isRunningAcceptanceTest() ? 0 : ACCORDION_TRANSITION_DURATION_IN_MS}
                     nodeRef={panelContainerRef}
                     classNames={styles.panelTransitionClasses}
                     mountOnEnter

--- a/src/loading-bar.tsx
+++ b/src/loading-bar.tsx
@@ -3,6 +3,7 @@ import {CSSTransition} from 'react-transition-group';
 import {Portal} from './portal';
 import * as styles from './loading-bar.css';
 import {getPrefixedDataAttributes} from './utils/dom';
+import {isRunningAcceptanceTest} from './utils/platform';
 
 import type {DataAttributes} from './utils/types';
 
@@ -12,7 +13,7 @@ const LoadingBar: React.FC<Props> = ({visible, dataAttributes}) => {
     return (
         <CSSTransition
             in={visible}
-            timeout={styles.TRANSITION_DURATION_MS}
+            timeout={isRunningAcceptanceTest() ? 0 : styles.TRANSITION_DURATION_MS}
             classNames={{
                 enter: styles.enter,
                 enterActive: styles.enterActive,

--- a/src/menu.tsx
+++ b/src/menu.tsx
@@ -16,6 +16,7 @@ import Divider from './divider';
 import Checkbox from './checkbox';
 import {CSSTransition} from 'react-transition-group';
 import {combineRefs} from './utils/common';
+import {isRunningAcceptanceTest} from './utils/platform';
 
 import type {ExclusifyUnion} from './utils/utility-types';
 import type {DataAttributes, IconProps} from './utils/types';
@@ -396,7 +397,7 @@ export const Menu: React.FC<MenuProps> = ({
                 <CSSTransition
                     in={isMenuOpen}
                     nodeRef={menuRef}
-                    timeout={MENU_TRANSITION_DURATION_IN_MS}
+                    timeout={isRunningAcceptanceTest() ? 0 : MENU_TRANSITION_DURATION_IN_MS}
                     classNames={styles.menuTransitionClasses}
                     mountOnEnter
                     unmountOnExit

--- a/src/navigation-bar.tsx
+++ b/src/navigation-bar.tsx
@@ -24,6 +24,7 @@ import {sprinkles} from './sprinkles.css';
 import {getPrefixedDataAttributes} from './utils/dom';
 import Stack from './stack';
 import Box from './box';
+import {isRunningAcceptanceTest} from './utils/platform';
 
 import type {Props as TouchableProps} from './touchable';
 import type {DataAttributes} from './utils/types';
@@ -231,7 +232,7 @@ export const MainNavigationBar: React.FC<MainNavigationBarProps> = ({
                                     setMenuTransitionState('closed');
                                 }}
                                 in={isMenuOpen}
-                                timeout={BURGER_MENU_ANIMATION_DURATION_MS}
+                                timeout={isRunningAcceptanceTest() ? 0 : BURGER_MENU_ANIMATION_DURATION_MS}
                                 unmountOnExit
                             >
                                 {(burgerMenuState) => (


### PR DESCRIPTION
Issue: [Link](https://jira.tid.es/browse/WEB-1622)

Using timeout for Transition/CSSTransition components in acceptance testing was causing some tests to fail ([Teams thread describing the issue](https://teams.microsoft.com/_?tenantId=9744600e-3e04-492e-baa1-25ec245c6f10#/conversations/unknown?threadId=19:be8725e15a8c4cc5ae1bf5d67fad4b7f@thread.skype&messageId=1699433116118&replyChainId=1699433116118&ctx=channel)).

By setting timeout to 0 in acceptance tests, the failing tests are fixed:
![image](https://github.com/Telefonica/mistica-web/assets/25785151/bbb8ae4c-c3bf-49f5-80c8-a481be8b31b5)
