### PR TITLE
feat(createNestableContext): allow custom valuesReducer

### DIFF
--- a/src/__tests__/nestable-context-test.tsx
+++ b/src/__tests__/nestable-context-test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import createContext from '../nestable-context';
+import {createNestableContext} from '../nestable-context';
 import {render, fireEvent, screen} from '@testing-library/react';
 
 test('happy case', () => {
-    const {Provider, Getter, Setter} = createContext<string>('nothing');
+    const {Provider, Getter, Setter} = createNestableContext<string>('nothing');
 
     render(
         <Provider>
@@ -16,7 +16,7 @@ test('happy case', () => {
 });
 
 test('When unmount, the default value is restored', async () => {
-    const {Provider, Getter, Setter} = createContext<string>('nothing');
+    const {Provider, Getter, Setter} = createNestableContext<string>('nothing');
 
     const A = () => {
         const [isVisible, setIsVisible] = React.useState(true);
@@ -42,7 +42,7 @@ test('When unmount, the default value is restored', async () => {
 });
 
 test('When unmount, the previous value is restored', async () => {
-    const {Provider, Getter, Setter} = createContext<string>('nothing');
+    const {Provider, Getter, Setter} = createNestableContext<string>('nothing');
 
     const A = () => {
         const [isVisible, setIsVisible] = React.useState(true);
@@ -70,7 +70,7 @@ test('When unmount, the previous value is restored', async () => {
 });
 
 test('when nesting, the innermost component wins', () => {
-    const {Provider, Getter, Setter} = createContext<string>('nothing');
+    const {Provider, Getter, Setter} = createNestableContext<string>('nothing');
 
     const C = () => <Setter value="c" />;
 
@@ -121,7 +121,7 @@ const Transition = ({a, b}: {a: React.ReactNode; b: React.ReactNode}) => {
 };
 
 test('works as expected with transitions', async () => {
-    const {Provider, Getter, Setter} = createContext<string>('nothing');
+    const {Provider, Getter, Setter} = createNestableContext<string>('nothing');
 
     render(
         <Provider>
@@ -136,7 +136,7 @@ test('works as expected with transitions', async () => {
 test('when value is an object, nested values are merged', () => {
     type Value = {foo?: string; bar?: string};
 
-    const {Provider, Getter, Setter} = createContext<Value>({});
+    const {Provider, Getter, Setter} = createNestableContext<Value>({});
 
     const C = () => <Setter value={{bar: 'c'}} />;
 
@@ -176,7 +176,7 @@ test('can use a custom valuesReducer', () => {
         }, {});
     };
 
-    const {Provider, Getter, Setter} = createContext<Value>({}, valuesReducer);
+    const {Provider, Getter, Setter} = createNestableContext<Value>({}, valuesReducer);
 
     const C = () => <Setter value={{bar: 'c'}} />;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,7 @@ export {default as Snackbar} from './snackbar';
 export {Portal} from './portal';
 export {default as LoadingBar} from './loading-bar';
 export {default as FixedToTop, TopDistanceContext} from './fixed-to-top';
-export {default as createNestableContext} from './nestable-context';
+export {createNestableContext} from './nestable-context';
 export type {NestableContext} from './nestable-context';
 export {default as OverscrollColor, OverscrollColorProvider} from './overscroll-color-context';
 export {

--- a/src/nestable-context.tsx
+++ b/src/nestable-context.tsx
@@ -44,7 +44,10 @@ export type NestableContext<Value> = {
     useSetValue: (value: Value) => void;
 };
 
-const createNestableContext = <Value,>(defaultValue: Value): NestableContext<Value> => {
+const createNestableContext = <Value,>(
+    defaultValue: Value,
+    valuesReducer?: (values: Array<Value>) => Value
+): NestableContext<Value> => {
     const DispatchContext = React.createContext<Dispatch<Value>>(() => {});
     const ValueContext = React.createContext<Value>(defaultValue);
 
@@ -94,7 +97,11 @@ const createNestableContext = <Value,>(defaultValue: Value): NestableContext<Val
         let computedValue: Value = defaultValue;
         if (values.length) {
             if (isObject(values[0])) {
-                computedValue = Object.assign({}, defaultValue, ...values);
+                if (valuesReducer) {
+                    computedValue = valuesReducer(values);
+                } else {
+                    computedValue = Object.assign({}, defaultValue, ...values);
+                }
             } else {
                 computedValue = values[values.length - 1];
             }

--- a/src/nestable-context.tsx
+++ b/src/nestable-context.tsx
@@ -44,7 +44,7 @@ export type NestableContext<Value> = {
     useSetValue: (value: Value) => void;
 };
 
-const createNestableContext = <Value,>(
+export const createNestableContext = <Value,>(
     defaultValue: Value,
     valuesReducer?: (values: Array<Value>) => Value
 ): NestableContext<Value> => {
@@ -138,5 +138,3 @@ const createNestableContext = <Value,>(
 
     return {Setter, Provider, Getter, useSetValue, useValue};
 };
-
-export default createNestableContext;

--- a/src/overscroll-color-context.tsx
+++ b/src/overscroll-color-context.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {useThemeVariant} from './theme-variant-context';
 import {useTheme, useScreenSize} from './hooks';
-import createNestableContext from './nestable-context';
+import {createNestableContext} from './nestable-context';
 import {isInsideNovumNativeApp, getPlatform} from './utils/platform';
 import {vars} from './skins/skin-contract.css';
 


### PR DESCRIPTION
jira: https://jira.tid.es/browse/WEB-1632

Webapp uses nestable-context for navbar state.
There is an special attribute in navbar state called `resetToDefaultState` that is used to reset the state of the navbar. 
https://github.com/Telefonica/webview-bridge/blob/master/src/utils.ts#L106-L110

When that attribute is used, the merging logic should be different. Something like this:
![image](https://github.com/Telefonica/mistica-web/assets/1849576/66b68661-3d14-4419-8e8c-0decc1151ad9)
