### PR TITLE
fix(Tooltip): make component reactive to changes in tooltip content

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -244,7 +244,8 @@ const getBoundingClientRect = (element: Element): BoundingRect => {
 
 export const useBoundingRect = (
     ref: React.RefObject<Element>,
-    computeOnEveryFrame = true
+    computeOnEveryFrame = true,
+    trackIfNotVisible = false
 ): BoundingRect | undefined => {
     const [rect, setRect] = React.useState<BoundingRect>();
     const isVisible = useIsInViewport(ref, false);
@@ -253,7 +254,7 @@ export const useBoundingRect = (
         let id: number;
 
         const check = () => {
-            if (ref.current && isVisible) {
+            if (ref.current && (isVisible || trackIfNotVisible)) {
                 const current = getBoundingClientRect(ref.current);
                 if (!isEqual(rect, current)) {
                     setRect(current);
@@ -272,7 +273,7 @@ export const useBoundingRect = (
         return () => {
             cancelAnimationFrame(id);
         };
-    }, [ref, rect, isVisible, computeOnEveryFrame]);
+    }, [ref, rect, isVisible, computeOnEveryFrame, trackIfNotVisible]);
 
     return rect;
 };

--- a/src/tooltip.tsx
+++ b/src/tooltip.tsx
@@ -193,6 +193,7 @@ const Tooltip: React.FC<Props> = ({
     const isInverse = useIsInverseVariant();
 
     const targetRect = useBoundingRect(targetRef, isTooltipOpen);
+    const tooltipRect = useBoundingRect(tooltipRef, isTooltipOpen, true);
     const windowSize = useWindowSize();
 
     const resetTooltipInteractions = React.useCallback(() => {
@@ -349,6 +350,7 @@ const Tooltip: React.FC<Props> = ({
     }, [
         tooltip,
         targetRect,
+        tooltipRect,
         isTooltipOpen,
         position,
         windowSize,


### PR DESCRIPTION
Some of the tooltip screenshot tests were failing randomly. The cause was the tooltip's width changing for some reason that we couldn't explain. Given that the component was not reactive to these changes, the tooltip ended up misaligned after the width changed.

In this PR, we force the tooltip to recompute its position when it's width/height changes, and therefore fixing the issue.