### PR TITLE
fix(Checkbox): wrong clickable area

### DIFF
--- a/src/inline.css.ts
+++ b/src/inline.css.ts
@@ -5,7 +5,7 @@ const space = createVar();
 export const vars = {space};
 
 export const inline = style({
-    pointerEvents: 'none', // to avoid the negative margins to affect clickable areas
+    pointerEvents: 'none', // to prevent negative margins from affecting clickable areas
     flexDirection: 'row',
     gridAutoFlow: 'column',
     marginTop: `calc(${space} * -1)`,

--- a/src/inline.css.ts
+++ b/src/inline.css.ts
@@ -5,7 +5,7 @@ const space = createVar();
 export const vars = {space};
 
 export const inline = style({
-    pointerEvents: 'none',
+    pointerEvents: 'none', // to avoid the negative margins to affect clickable areas
     flexDirection: 'row',
     gridAutoFlow: 'column',
     marginTop: `calc(${space} * -1)`,
@@ -37,6 +37,7 @@ export const noFullWidth = style([
 globalStyle(`${inline} > div`, {
     marginLeft: space,
     marginTop: space,
+    pointerEvents: 'auto', // restore pointer events for children
 });
 
 globalStyle(`${inline} > div:empty`, {

--- a/src/inline.css.ts
+++ b/src/inline.css.ts
@@ -5,6 +5,7 @@ const space = createVar();
 export const vars = {space};
 
 export const inline = style({
+    pointerEvents: 'none',
     flexDirection: 'row',
     gridAutoFlow: 'column',
     marginTop: `calc(${space} * -1)`,


### PR DESCRIPTION
https://jira.tid.es/browse/WEB-1669

In global ecommerce, we have a list of checkboxes. Sometimes, when the user clicks on one, the below one is activated instead. This is caused by the clickable area of the checkbox:

![image](https://github.com/Telefonica/mistica-web/assets/1849576/bbf91b04-1e39-4369-b6a0-f39ea5c66c58)

The issue is caused by Inline margins:
![image](https://github.com/Telefonica/mistica-web/assets/1849576/ad14ffa5-5ff0-4f7d-b462-11065de3313b)

The simpler fix I could think of is removing pointer-events from `Inline` parent `div`. I can't think of a case where this could be problematic. After this fix, the clickable area is the one of the `Checkbox` parent `div`, not the `Inline` children:

![image](https://github.com/Telefonica/mistica-web/assets/1849576/005298d2-266a-44b3-9130-84e621879a2e)

A simpler/elegant fix would be stop using margins and use flex gap in `Inline`, but we can't use it yet:
![image](https://github.com/Telefonica/mistica-web/assets/1849576/3dde715f-8df3-4774-8d71-b11493e4f6b6)

grid gap has better support, but not enough:
![image](https://github.com/Telefonica/mistica-web/assets/1849576/c54d9d43-a536-4080-987f-f64db9b7bdae)



