### PR TITLE
fix(Overlay): stop event propagation on click

### DIFF
--- a/src/__tests__/overlay-test.tsx
+++ b/src/__tests__/overlay-test.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import {render, screen} from '@testing-library/react';
+import ThemeContextProvider from '../theme-context-provider';
+import {makeTheme} from './test-utils';
+import userEvent from '@testing-library/user-event';
+import {Overlay} from '..';
+
+test('Overlay click should not be propagated', async () => {
+    const handleParentClick = jest.fn();
+    const handleOverlayPress = jest.fn();
+
+    render(
+        <ThemeContextProvider theme={makeTheme()}>
+            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+            <div onClick={handleParentClick}>
+                <Overlay onPress={handleOverlayPress} dataAttributes={{testid: 'overlay'}} />
+            </div>
+        </ThemeContextProvider>
+    );
+
+    const overlay = screen.getByTestId('overlay');
+
+    expect(overlay).toBeInTheDocument();
+    await userEvent.click(overlay);
+    expect(handleOverlayPress).toHaveBeenCalled();
+    expect(handleParentClick).not.toHaveBeenCalled();
+});

--- a/src/overlay.tsx
+++ b/src/overlay.tsx
@@ -61,6 +61,7 @@ const Overlay: React.FC<Props> = ({
                 }
             }}
             onClick={(e) => {
+                e.stopPropagation();
                 // In Android we need to call onPress here in onClick to ensure click event doesn't hit element below overlay.
                 if (
                     (e.target as any).dataset.overlay &&


### PR DESCRIPTION
WEB-1663

Playroom code to verify:
```
N4Igxg9gJgpiBcIA8AVCBXMALAhgIwBsYAdAOwAJyJSAFAJxgGdGBeYACgEpyWA%2BcnEToAXdsHIBbJoxwBzGPHLEQGYYwCWsZeQC%2BnHWUqNhATyJtxeCHVh1FygIwAHAB7lGEApvIMo2nQakvIbkSABCEG5OOFBQ6qSybA4AbDrBFJShALIwpOghmT65tig4dPLCbGJFAGYANFS0DMwN6ow5eQDyTrm63Hzk7AWFoWHowsLU9OoSZSbDI7VsDDWBi4VTzawcMP38wAvrMAB0xhBO9OdyOMLq1FwA3IeLm9KPz5kBH0am5sDisxcAHVNMIsPYQDV1MIALSQUjCXLCfxrdbpdaZYBtDrobq9AD8ShAAGECBBGCQQOQIXjSMpUYskAB6MYTTYzObokb6Q4MUi2HFVcQrBpgAg4ZgAORwUj6PH4QwyjLiADclsAVjpyGKJYxpVI2DqpTKYGlvtlcugAJKIiTmyjivAwAgsZTnW7UcgOZT2xr0aRVPYCISiAHSOQKIlSPJUJweulUvQM9ZMrmMpmqtOZHlK8ipkLMiIudLMtCYXCEGDpEB1EBgmBSRgIADaICyEBVbWEZRAAF1awB3UFYJvwZsOADMyQAHL2dEA
```

* [x] Fix verified in global checkout repo