### PR TITLE
fix(InputFields): Align text to the left in date/time input fields. In iOS they are centered by default.

### DIFF
--- a/src/text-field-base.css.ts
+++ b/src/text-field-base.css.ts
@@ -142,6 +142,10 @@ export const input = style([
                 transitionProperty: 'background-color',
                 transitionDelay: '99999s',
             },
+            // iOS date/time fields are centered by default, but we want them left aligned
+            '&::-webkit-date-and-time-value': {
+                textAlign: 'left',
+            },
         },
     },
     commonInputStyles,


### PR DESCRIPTION
WEB-1691
