### PR TITLE
feat(Video): `stop` method. To stop video and show the poster (if available)

### DIFF
--- a/src/__stories__/video-story.tsx
+++ b/src/__stories__/video-story.tsx
@@ -103,9 +103,7 @@ export const Default: StoryComponent<Args> = ({
                     <ButtonPrimary
                         small
                         onPress={() => {
-                            if (videoRef.current) {
-                                videoRef.current.play();
-                            }
+                            videoRef.current?.play();
                         }}
                     >
                         Play
@@ -116,9 +114,18 @@ export const Default: StoryComponent<Args> = ({
                             videoRef.current?.pause();
                         }}
                     >
+                        Pause
+                    </ButtonPrimary>
+                    <ButtonPrimary
+                        small
+                        onPress={() => {
+                            videoRef.current?.stop();
+                        }}
+                    >
                         Stop
                     </ButtonPrimary>
                 </Inline>
+
                 {video}
             </Stack>
         </Stack>

--- a/src/video.tsx
+++ b/src/video.tsx
@@ -288,6 +288,8 @@ const Video = React.forwardRef<VideoElement, VideoProps>(
 
                         if (containerElement) {
                             containerElement.play = () => {
+                                // old browsers don't return a promise when calling play()
+                                // see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#browser_compatibility
                                 return videoRef.current?.play() || Promise.resolve();
                             };
                             containerElement.pause = () => videoRef.current?.pause();

--- a/src/video.tsx
+++ b/src/video.tsx
@@ -10,9 +10,9 @@ import classNames from 'classnames';
 
 import type {DataAttributes} from './utils/types';
 
-type VideoState = 'loading' | 'loaded' | 'playing' | 'paused' | 'error';
+type VideoState = 'loading' | 'loaded' | 'playing' | 'paused' | 'error' | 'stopped';
 
-type VideoAction = 'play' | 'finishLoad' | 'pause' | 'fail' | 'reset';
+type VideoAction = 'play' | 'finishLoad' | 'pause' | 'fail' | 'reset' | 'stop';
 
 const transitions: Record<VideoState, Partial<Record<VideoAction, VideoState>>> = {
     loading: {
@@ -36,20 +36,28 @@ const transitions: Record<VideoState, Partial<Record<VideoAction, VideoState>>> 
     playing: {
         pause: 'paused',
         reset: 'loading',
+        stop: 'stopped',
     },
 
     paused: {
         play: 'playing',
         reset: 'loading',
+        stop: 'stopped',
     },
 
     error: {
         reset: 'loading',
     },
+
+    stopped: {
+        play: 'playing',
+        reset: 'loading',
+    },
 };
 
-const videoReducer = (state: VideoState, action: VideoAction): VideoState =>
-    transitions[state][action] || state;
+const videoReducer = (state: VideoState, action: VideoAction): VideoState => {
+    return transitions[state][action] || state;
+};
 
 export type AspectRatio = '1:1' | '16:9' | '4:3';
 
@@ -105,6 +113,8 @@ export interface VideoElement extends HTMLDivElement {
     play: () => Promise<void>;
     pause: () => void;
     load: () => void;
+    /** Stops the video and shows the poster image (if available) */
+    stop: () => void;
     setCurrentTime: (time: number) => void;
 }
 
@@ -174,6 +184,7 @@ const Video = React.forwardRef<VideoElement, VideoProps>(
             dispatch('finishLoad');
             if (video && shouldAutoPlay && video.paused) {
                 video.play();
+                dispatch('play');
             }
         };
 
@@ -186,7 +197,7 @@ const Video = React.forwardRef<VideoElement, VideoProps>(
             }
         });
 
-        const showPoster = videoStatus === 'error' || videoStatus === 'loading' || videoStatus === 'loaded';
+        const showPoster = ['error', 'loading', 'loaded', 'stopped'].includes(videoStatus);
 
         const video = (
             <video
@@ -204,6 +215,7 @@ const Video = React.forwardRef<VideoElement, VideoProps>(
                     dispatch('pause');
                 }}
                 onTimeUpdate={() => {
+                    // The state update is performed here instead of in "onPlay" to avoid flickering when hiding the poster
                     if (videoStatus !== 'playing' && videoRef.current?.currentTime !== 0) {
                         onPlay?.();
                         dispatch('play');
@@ -271,7 +283,9 @@ const Video = React.forwardRef<VideoElement, VideoProps>(
                         const containerElement = element ? (element as VideoElement) : null;
 
                         if (containerElement) {
-                            containerElement.play = () => videoRef.current?.play() || Promise.resolve();
+                            containerElement.play = () => {
+                                return videoRef.current?.play() || Promise.resolve();
+                            };
                             containerElement.pause = () => videoRef.current?.pause();
                             containerElement.load = () => {
                                 /**
@@ -298,6 +312,13 @@ const Video = React.forwardRef<VideoElement, VideoProps>(
                             containerElement.setCurrentTime = (time: number) => {
                                 if (videoRef.current) {
                                     videoRef.current.currentTime = time;
+                                }
+                            };
+                            containerElement.stop = () => {
+                                if (videoRef.current) {
+                                    videoRef.current.pause();
+                                    videoRef.current.currentTime = 0;
+                                    dispatch('stop');
                                 }
                             };
                         }

--- a/src/video.tsx
+++ b/src/video.tsx
@@ -178,6 +178,10 @@ const Video = React.forwardRef<VideoElement, VideoProps>(
 
         const handleLoadFinish = () => {
             onLoad?.();
+            if (videoStatus === 'stopped') {
+                // the video was intentionally stopped
+                return;
+            }
             const video = videoRef.current;
             const shouldAutoPlay = autoPlay && !isRunningAcceptanceTest();
 


### PR DESCRIPTION
WEB-1713

After releasing this fix, the following change is required in webapp

```diff
$ git diff
diff --git a/web/src/explore/hooks/use-card-media-element.tsx b/web/src/explore/hooks/use-card-media-element.tsx
index 2ef3e7a5da..c3b2ec6892 100644
--- a/web/src/explore/hooks/use-card-media-element.tsx
+++ b/web/src/explore/hooks/use-card-media-element.tsx
@@ -54,7 +54,7 @@ export const useCardMediaElement = ({
         onExit: (ref) => {
             // Should reset and display the poster image
             if (!isRunningAcceptanceTest()) {
-                ref?.load();
+                ref?.stop();
             }
         },
         threshold: 0.25,
```