### PR TITLE
fix(Image): reset error state when src changes

### DIFF
--- a/src/__stories__/image-story.tsx
+++ b/src/__stories__/image-story.tsx
@@ -67,19 +67,7 @@ export const Default: StoryComponent<Args> = ({
         dataAttributes: {testid: 'image'},
     };
 
-    const image = <Image src={usingVrImg} {...props} />;
-    const emptySourceImage = <Image src="" {...props} />;
-
-    /**
-     * For some reason, if we write this logic with a conditional (isEmptySource ? error : image),
-     * the image element triggers an error when switching the isEmptySource control from true to false
-     */
-    return (
-        <>
-            {!isEmptySource && image}
-            {isEmptySource && emptySourceImage}
-        </>
-    );
+    return <Image src={isEmptySource ? '' : usingVrImg} {...props} />;
 };
 
 Default.storyName = 'Image';

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -183,6 +183,10 @@ export const ImageContent = React.forwardRef<HTMLImageElement, ImageProps>(
         }, [onLoad]);
 
         React.useEffect(() => {
+            setIsError(!src);
+        }, [src]);
+
+        React.useEffect(() => {
             // Needed because there is some race condition with SSR and onLoad events
             // load event could be fired before the component is hydrated and mounted client side
             // https://github.com/facebook/react/issues/15446

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -184,6 +184,7 @@ export const ImageContent = React.forwardRef<HTMLImageElement, ImageProps>(
 
         React.useEffect(() => {
             setIsError(!src);
+            setHideLoadingFallback(false);
         }, [src]);
 
         React.useEffect(() => {


### PR DESCRIPTION
Issue: [Link](https://jira.tid.es/browse/WEB-1802)

Context: [Teams thread](https://teams.microsoft.com/l/message/19:be8725e15a8c4cc5ae1bf5d67fad4b7f@thread.skype/1711548515702?tenantId=9744600e-3e04-492e-baa1-25ec245c6f10&groupId=bef9be07-03e4-4afb-8a79-f720a63e4c28&parentMessageId=1711548515702&teamName=Novum&channelName=WebCore-public&createdTime=1711548515702&allowXTenantAccess=false)

This PR also solves a similar issue [reported in Github](https://github.com/Telefonica/mistica-web/issues/1028)