### PR TITLE
feat(Accordion,Callout,Cards,EmptyState,Header,Hero,Row,NavigationBar): added titleAs prop to allow configuring heading level

### DIFF
--- a/src/accordion.tsx
+++ b/src/accordion.tsx
@@ -35,6 +35,7 @@ export const useAccordionContext = (): AccordionContextType => React.useContext(
 interface AccordionItemContentProps {
     children?: void;
     title: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     subtitle?: string;
     asset?: React.ReactNode;
     content: React.ReactNode;

--- a/src/accordion.tsx
+++ b/src/accordion.tsx
@@ -35,7 +35,7 @@ export const useAccordionContext = (): AccordionContextType => React.useContext(
 interface AccordionItemContentProps {
     children?: void;
     title: string;
-    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+    titleAs?: string;
     subtitle?: string;
     asset?: React.ReactNode;
     content: React.ReactNode;

--- a/src/callout.tsx
+++ b/src/callout.tsx
@@ -22,6 +22,7 @@ import type {DataAttributes, RendersNullableElement} from './utils/types';
 
 type Props = {
     title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     description: string;
     onClose?: () => void;
     icon?: React.ReactElement;
@@ -35,6 +36,7 @@ type Props = {
 
 const Callout: React.FC<Props> = ({
     title,
+    titleAs = 'h2',
     description,
     icon,
     onClose,
@@ -70,7 +72,7 @@ const Callout: React.FC<Props> = ({
                     <Stack space={16}>
                         <Inline fullWidth alignItems="flex-start" space="between">
                             <Stack space={4}>
-                                <Text3 as="h2" regular>
+                                <Text3 as={titleAs} regular>
                                     {title}
                                 </Text3>
                                 <Text2 as="p" regular color={vars.colors.textSecondary}>

--- a/src/card.tsx
+++ b/src/card.tsx
@@ -350,6 +350,7 @@ type CardContentProps = {
     pretitle?: string;
     pretitleLinesMax?: number;
     title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     titleLinesMax?: number;
     subtitle?: string;
     subtitleLinesMax?: number;
@@ -365,6 +366,7 @@ const CardContent: React.FC<CardContentProps> = ({
     pretitle,
     pretitleLinesMax,
     title,
+    titleAs = 'h3',
     titleLinesMax,
     subtitle,
     subtitleLinesMax,
@@ -412,7 +414,7 @@ const CardContent: React.FC<CardContentProps> = ({
                                         desktopLineHeight="28px"
                                         truncate={titleLinesMax}
                                         weight={textPresets.cardTitle.weight}
-                                        as="h3"
+                                        as={titleAs}
                                         hyphens="auto"
                                     >
                                         {title}
@@ -468,6 +470,7 @@ interface MediaCardBaseProps {
     pretitle?: string;
     pretitleLinesMax?: number;
     title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     titleLinesMax?: number;
     subtitle?: string;
     subtitleLinesMax?: number;
@@ -501,6 +504,7 @@ export const MediaCard = React.forwardRef<HTMLDivElement, MediaCardProps>(
             subtitle,
             subtitleLinesMax,
             title,
+            titleAs = 'h3',
             titleLinesMax,
             description,
             descriptionLinesMax,
@@ -542,6 +546,7 @@ export const MediaCard = React.forwardRef<HTMLDivElement, MediaCardProps>(
                                     pretitle={pretitle}
                                     pretitleLinesMax={pretitleLinesMax}
                                     title={title}
+                                    titleAs={titleAs}
                                     titleLinesMax={titleLinesMax}
                                     subtitle={subtitle}
                                     subtitleLinesMax={subtitleLinesMax}
@@ -587,6 +592,7 @@ export const NakedCard = React.forwardRef<HTMLDivElement, MediaCardProps>(
             subtitle,
             subtitleLinesMax,
             title,
+            titleAs = 'h3',
             titleLinesMax,
             description,
             descriptionLinesMax,
@@ -629,6 +635,7 @@ export const NakedCard = React.forwardRef<HTMLDivElement, MediaCardProps>(
                                 pretitle={pretitle}
                                 pretitleLinesMax={pretitleLinesMax}
                                 title={title}
+                                titleAs={titleAs}
                                 titleLinesMax={titleLinesMax}
                                 subtitle={subtitle}
                                 subtitleLinesMax={subtitleLinesMax}
@@ -665,6 +672,7 @@ export const NakedCard = React.forwardRef<HTMLDivElement, MediaCardProps>(
 type SmallNakedCardProps = MaybeTouchableCard<{
     media: RendersElement<typeof Image> | RendersElement<typeof Video>;
     title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     titleLinesMax?: number;
     subtitle?: string;
     subtitleLinesMax?: number;
@@ -680,6 +688,7 @@ export const SmallNakedCard = React.forwardRef<HTMLDivElement, SmallNakedCardPro
         {
             media,
             title,
+            titleAs = 'h3',
             titleLinesMax,
             subtitle,
             subtitleLinesMax,
@@ -718,7 +727,7 @@ export const SmallNakedCard = React.forwardRef<HTMLDivElement, SmallNakedCardPro
                             <div>
                                 <Stack space={8}>
                                     {title && (
-                                        <Text2 truncate={titleLinesMax} as="h3" regular hyphens="auto">
+                                        <Text2 truncate={titleLinesMax} as={titleAs} regular hyphens="auto">
                                             {title}
                                         </Text2>
                                     )}
@@ -758,6 +767,7 @@ interface DataCardBaseProps {
     pretitle?: string;
     pretitleLinesMax?: number;
     title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     titleLinesMax?: number;
     subtitle?: string;
     subtitleLinesMax?: number;
@@ -790,6 +800,7 @@ export const DataCard = React.forwardRef<HTMLDivElement, DataCardProps>(
             pretitle,
             pretitleLinesMax,
             title,
+            titleAs = 'h3',
             titleLinesMax,
             subtitle,
             subtitleLinesMax,
@@ -846,6 +857,7 @@ export const DataCard = React.forwardRef<HTMLDivElement, DataCardProps>(
                                         pretitle={pretitle}
                                         pretitleLinesMax={pretitleLinesMax}
                                         title={title}
+                                        titleAs={titleAs}
                                         titleLinesMax={titleLinesMax}
                                         subtitle={subtitle}
                                         subtitleLinesMax={subtitleLinesMax}
@@ -883,6 +895,7 @@ export const DataCard = React.forwardRef<HTMLDivElement, DataCardProps>(
 type SnapCardProps = MaybeTouchableCard<{
     icon?: React.ReactElement;
     title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     titleLinesMax?: number;
     subtitle?: string;
     subtitleLinesMax?: number;
@@ -900,6 +913,7 @@ export const SnapCard = React.forwardRef<HTMLDivElement, SnapCardProps>(
         {
             icon,
             title,
+            titleAs = 'h3',
             titleLinesMax,
             subtitle,
             subtitleLinesMax,
@@ -943,7 +957,7 @@ export const SnapCard = React.forwardRef<HTMLDivElement, SnapCardProps>(
                                 )}
                                 <Stack space={4}>
                                     {title && (
-                                        <Text2 truncate={titleLinesMax} as="h3" regular hyphens="auto">
+                                        <Text2 truncate={titleLinesMax} as={titleAs} regular hyphens="auto">
                                             {title}
                                         </Text2>
                                     )}
@@ -981,6 +995,7 @@ interface CommonDisplayCardProps {
     pretitle?: string;
     pretitleLinesMax?: number;
     title: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     titleLinesMax?: number;
     description?: string;
     descriptionLinesMax?: number;
@@ -1043,6 +1058,7 @@ const DisplayCard = React.forwardRef<HTMLDivElement, GenericDisplayCardProps>(
             pretitle,
             pretitleLinesMax,
             title,
+            titleAs = 'h3',
             titleLinesMax,
             description,
             descriptionLinesMax,
@@ -1175,7 +1191,7 @@ const DisplayCard = React.forwardRef<HTMLDivElement, GenericDisplayCardProps>(
                                                                 <Text6
                                                                     forceMobileSizes
                                                                     truncate={titleLinesMax}
-                                                                    as="h3"
+                                                                    as={titleAs}
                                                                     textShadow={textShadow}
                                                                     hyphens="auto"
                                                                 >
@@ -1263,6 +1279,7 @@ interface PosterCardBaseProps {
     pretitle?: string;
     pretitleLinesMax?: number;
     title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     titleLinesMax?: number;
     subtitle?: string;
     subtitleLinesMax?: number;
@@ -1314,6 +1331,7 @@ export const PosterCard = React.forwardRef<HTMLDivElement, PosterCardProps>(
             pretitle,
             pretitleLinesMax,
             title,
+            titleAs = 'h3',
             titleLinesMax,
             subtitle,
             subtitleLinesMax,
@@ -1466,7 +1484,7 @@ export const PosterCard = React.forwardRef<HTMLDivElement, PosterCardProps>(
                                                                     desktopLineHeight="28px"
                                                                     truncate={titleLinesMax}
                                                                     weight={textPresets.cardTitle.weight}
-                                                                    as="h3"
+                                                                    as={titleAs}
                                                                     hyphens="auto"
                                                                 >
                                                                     {title}

--- a/src/empty-state-card.tsx
+++ b/src/empty-state-card.tsx
@@ -14,6 +14,7 @@ import type {DataAttributes, RendersNullableElement} from './utils/types';
 
 interface CommonProps {
     title: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     button?: RendersNullableElement<typeof ButtonPrimary>;
     secondaryButton?: RendersNullableElement<typeof ButtonSecondary>;
     buttonLink?: RendersNullableElement<typeof ButtonLink>;
@@ -38,6 +39,7 @@ type Props = IconProps | ImageProps;
 
 const EmptyStateCard: React.FC<Props> = ({
     title,
+    titleAs = 'h3',
     description,
     button,
     secondaryButton,
@@ -70,6 +72,7 @@ const EmptyStateCard: React.FC<Props> = ({
                                     desktopSize={20}
                                     desktopLineHeight="28px"
                                     weight={textPresets.cardTitle.weight}
+                                    as={titleAs}
                                 >
                                     {title}
                                 </Text>

--- a/src/empty-state.tsx
+++ b/src/empty-state.tsx
@@ -20,6 +20,7 @@ import type {DataAttributes, RendersNullableElement} from './utils/types';
 
 interface BaseProps {
     title: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     button?: RendersNullableElement<typeof ButtonPrimary> | RendersNullableElement<typeof ButtonSecondary>;
     buttonLink?: RendersNullableElement<typeof ButtonLink>;
     description?: string;
@@ -54,6 +55,7 @@ type Props = IconProps | ImageProps | LargeImageProps;
 
 const EmptyState: React.FC<Props> = ({
     title,
+    titleAs = 'h1',
     description,
     button,
     buttonLink,
@@ -96,7 +98,7 @@ const EmptyState: React.FC<Props> = ({
                 >
                     {image ?? (icon && <div className={styles.iconContainer}>{icon}</div>)}
                     <Stack space={16}>
-                        <Text6 as="h1">{title}</Text6>
+                        <Text6 as={titleAs}>{title}</Text6>
                         <Text3
                             regular
                             as="p"

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -29,6 +29,7 @@ type RichText = string | ({text: string} & OverridableTextProps);
 type HeaderProps = {
     pretitle?: RichText;
     title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     description?: string;
     small?: boolean;
     dataAttributes?: DataAttributes;
@@ -61,6 +62,7 @@ type HeaderProps = {
 export const Header: React.FC<HeaderProps> = ({
     pretitle,
     title,
+    titleAs = 'h2',
     description,
     dataAttributes,
     small = false,
@@ -96,7 +98,11 @@ export const Header: React.FC<HeaderProps> = ({
                     <Stack space={8}>
                         {pretitle && renderRichText(pretitle, {color: vars.colors.textPrimary})}
                         {title &&
-                            (small ? <Title2 as="h2">{title}</Title2> : <Title3 as="h2">{title}</Title3>)}
+                            (small ? (
+                                <Title2 as={titleAs}>{title}</Title2>
+                            ) : (
+                                <Title3 as={titleAs}>{title}</Title3>
+                            ))}
                         {description &&
                             (small ? (
                                 <Text2 regular color={vars.colors.textSecondary}>
@@ -138,19 +144,21 @@ export const Header: React.FC<HeaderProps> = ({
 
 type MainSectionHeaderProps = {
     title: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     description?: string;
     button?: RendersNullableElement<typeof ButtonPrimary> | RendersNullableElement<typeof ButtonSecondary>;
 };
 
-export const MainSectionHeader: React.FC<MainSectionHeaderProps> = ({title, description, button}) => {
+export const MainSectionHeader: React.FC<MainSectionHeaderProps> = ({
+    title,
+    titleAs = 'h1',
+    description,
+    button,
+}) => {
     return (
         <Stack space={32}>
             <Stack space={{mobile: 12, desktop: 16}}>
-                {title && (
-                    <Text7 role="heading" aria-level={1}>
-                        {title}
-                    </Text7>
-                )}
+                {title && <Text7 as={titleAs}>{title}</Text7>}
                 {description && <Text6>{description}</Text6>}
             </Stack>
             {button}

--- a/src/hero.tsx
+++ b/src/hero.tsx
@@ -38,6 +38,7 @@ type HeroContentProps = {
     headline?: RendersNullableElement<typeof Tag>;
     pretitle?: string;
     title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     description?: string;
     descriptionLinesMax?: number;
     extra?: React.ReactNode;
@@ -49,6 +50,7 @@ type HeroContentProps = {
 const HeroContent = ({
     headline,
     title,
+    titleAs = 'h1',
     pretitle,
     description,
     descriptionLinesMax,
@@ -75,7 +77,7 @@ const HeroContent = ({
                                 {pretitle}
                             </Text3>
                         )}
-                        {title && <Text8 as="h1">{title}</Text8>}
+                        {title && <Text8 as={titleAs}>{title}</Text8>}
                     </Stack>
                     {description && (
                         <Text3
@@ -106,6 +108,7 @@ type HeroProps = {
     headline?: RendersNullableElement<typeof Tag>;
     pretitle?: string;
     title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     description?: string;
     descriptionLinesMax?: number;
     extra?: React.ReactNode;

--- a/src/highlighted-card.tsx
+++ b/src/highlighted-card.tsx
@@ -28,9 +28,8 @@ type TextProps =
       };
 
 type CommonProps = TextProps & {
-    title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     titleLinesMax?: number;
-    description?: string;
     descriptionLinesMax?: number;
     imageUrl?: string;
     imageFit?: 'fit' | 'fill' | 'fill-center';
@@ -87,7 +86,7 @@ type OnPressProps = CommonProps & {
 type Props = BasicProps | ButtonProps | HrefProps | ToProps | OnPressProps;
 
 const Content = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
-    const {title, description, imageUrl, imageFit} = props;
+    const {title, description, imageUrl, imageFit, titleAs = 'h3'} = props;
     const isInverseOutside = useIsInverseVariant();
     const isInverse = props.isInverse ?? isInverseOutside;
     const isDismissable = useIsDismissable();
@@ -118,7 +117,7 @@ const Content = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
                             desktopLineHeight="28px"
                             truncate={props.titleLinesMax}
                             weight={textPresets.cardTitle.weight}
-                            as="h3"
+                            as={titleAs}
                             hyphens="auto"
                         >
                             {title}

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -37,7 +37,7 @@ interface CommonProps {
     children?: void; // no children allowed
     headline?: string | React.ReactNode;
     title: string;
-    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+    titleAs?: string;
     titleLinesMax?: number;
     subtitle?: string;
     subtitleLinesMax?: number;
@@ -77,7 +77,7 @@ export const Content: React.FC<ContentProps> = ({
     withChevron,
     headline,
     title,
-    titleAs = 'h3',
+    titleAs,
     titleLinesMax,
     subtitle,
     subtitleLinesMax,

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -37,6 +37,7 @@ interface CommonProps {
     children?: void; // no children allowed
     headline?: string | React.ReactNode;
     title: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     titleLinesMax?: number;
     subtitle?: string;
     subtitleLinesMax?: number;
@@ -76,6 +77,7 @@ export const Content: React.FC<ContentProps> = ({
     withChevron,
     headline,
     title,
+    titleAs = 'h3',
     titleLinesMax,
     subtitle,
     subtitleLinesMax,
@@ -140,6 +142,7 @@ export const Content: React.FC<ContentProps> = ({
                             truncate={titleLinesMax}
                             id={labelId}
                             hyphens="auto"
+                            as={titleAs}
                         >
                             {title}
                         </Text3>

--- a/src/navigation-bar.tsx
+++ b/src/navigation-bar.tsx
@@ -303,6 +303,7 @@ interface NavigationBarCommonProps {
     isInverse?: boolean;
     onBack?: () => void;
     title?: string;
+    titleAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     right?: React.ReactElement;
     withBorder?: boolean;
     children?: undefined;
@@ -323,6 +324,7 @@ type NavigationBarProps = NavigationBarTopFixedProps | NavigationBarNotFixedProp
 export const NavigationBar: React.FC<NavigationBarProps> = ({
     onBack,
     title,
+    titleAs,
     right,
     isInverse = false,
     topFixed = true,
@@ -342,7 +344,7 @@ export const NavigationBar: React.FC<NavigationBarProps> = ({
                         bleedRight
                     />
                 )}
-                <Text3 regular truncate>
+                <Text3 regular truncate as={titleAs}>
                     {title}
                 </Text3>
             </Inline>


### PR DESCRIPTION
WEB-1796 

I've intentionally not made it configurable in some components:
- Full screen components like feedback screen: because there shouldn't be any reason to not use `<h1>` there
- Some components like tooltip/popover. I think it's fine to always render a simple `<span>` in those cases