### PR TITLE
fix(Row): not having full width in some cases

### DIFF
--- a/src/list.tsx
+++ b/src/list.tsx
@@ -27,6 +27,7 @@ import * as mediaStyles from './image.css';
 import {vars} from './skins/skin-contract.css';
 import {applyCssVars} from './utils/css';
 import {IconButton, ToggleIconButton} from './icon-button';
+import {sprinkles} from '../src/sprinkles.css';
 
 import type {IconButtonProps, ToggleIconButtonProps} from './icon-button';
 import type {TouchableElement} from './touchable';
@@ -657,7 +658,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
 
 export const Row = React.forwardRef<TouchableElement, RowContentProps>(
     ({dataAttributes, role = 'listitem', ...props}, ref) => (
-        <div role={role}>
+        <div role={role} className={sprinkles({width: '100%'})}>
             <RowContent {...props} ref={ref} dataAttributes={{'component-name': 'Row', ...dataAttributes}} />
         </div>
     )


### PR DESCRIPTION
Issue found when updating mistica in Novum webapp:
![image](https://github.com/Telefonica/mistica-web/assets/1849576/6b6b4963-d46b-4ae2-a4a9-ea4f40c54578)

This is caused because they are wrapping rows with a flex div