### PR TITLE
fix(utils): use `location.assign` to redirect, instead of `location.href`

### DIFF
--- a/src/utils/__tests__/browser-test.tsx
+++ b/src/utils/__tests__/browser-test.tsx
@@ -1,8 +1,8 @@
 import {redirect} from '../browser';
 
 // mock location.assign
-const assignSpy = jest.fn();
-Object.defineProperty(window, 'location', {value: {...window.location, assign: assignSpy}});
+const redirectSpy = jest.fn();
+Object.defineProperty(window, 'location', {value: {...window.location, assign: redirectSpy}});
 
 // mock window.open
 const openSpy = jest.fn();
@@ -14,18 +14,15 @@ afterEach(() => {
 
 test('redirect', () => {
     redirect('https://example.org');
-    expect(assignSpy).toHaveBeenCalledWith('https://example.org');
-    expect(openSpy).not.toHaveBeenCalled();
+    expect(redirectSpy.mock.calls).toEqual([['https://example.org']]);
 });
 
 test('open external', () => {
     redirect('https://example.org', true, false);
-    expect(assignSpy).not.toHaveBeenCalled();
-    expect(openSpy).toHaveBeenCalledWith('https://example.org', '_blank');
+    expect(openSpy.mock.calls).toEqual([['https://example.org', '_blank']]);
 });
 
 test('open loadOnTop', () => {
     redirect('https://example.org', false, true);
-    expect(assignSpy).not.toHaveBeenCalled();
-    expect(openSpy).toHaveBeenCalledWith('https://example.org', '_top');
+    expect(openSpy.mock.calls).toEqual([['https://example.org', '_top']]);
 });

--- a/src/utils/__tests__/browser-test.tsx
+++ b/src/utils/__tests__/browser-test.tsx
@@ -1,0 +1,31 @@
+import {redirect} from '../browser';
+
+// mock location.assign
+const assignSpy = jest.fn();
+Object.defineProperty(window, 'location', {value: {...window.location, assign: assignSpy}});
+
+// mock window.open
+const openSpy = jest.fn();
+window.open = openSpy;
+
+afterEach(() => {
+    jest.resetAllMocks(); // reset spy calls
+});
+
+test('redirect', () => {
+    redirect('https://example.org');
+    expect(assignSpy).toHaveBeenCalledWith('https://example.org');
+    expect(openSpy).not.toHaveBeenCalled();
+});
+
+test('open external', () => {
+    redirect('https://example.org', true, false);
+    expect(assignSpy).not.toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalledWith('https://example.org', '_blank');
+});
+
+test('open loadOnTop', () => {
+    redirect('https://example.org', false, true);
+    expect(assignSpy).not.toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalledWith('https://example.org', '_top');
+});

--- a/src/utils/browser.tsx
+++ b/src/utils/browser.tsx
@@ -4,6 +4,6 @@ export const redirect = (url: string, external = false, loadOnTop = false): void
     } else if (loadOnTop) {
         window.open(url, '_top');
     } else {
-        document.location.href = url;
+        window.location.assign(url);
     }
 };


### PR DESCRIPTION
This will make easier to test redirects in unit tests