### PR TITLE
feat(Theme): expose `colorValues` in theme

### DIFF
--- a/src/theme-context-provider.tsx
+++ b/src/theme-context-provider.tsx
@@ -90,13 +90,12 @@ const ThemeContextProvider: React.FC<Props> = ({theme, children, as}) => {
     const isDarkModeEnabled = (colorScheme === 'auto' && isOsDarkModeEnabled) || colorScheme === 'dark';
     const colors: Colors = isDarkModeEnabled ? darkColors : lightColors;
 
-    const contextTheme = React.useMemo<Theme>(() => {
+    const contextTheme = React.useMemo((): Theme => {
         const platformOverrides = {
             platform: getPlatform(),
             insideNovumNativeApp: isInsideNovumNativeApp(),
             ...theme.platformOverrides,
         };
-
         return {
             skinName: theme.skin.name,
             i18n: theme.i18n,
@@ -110,6 +109,7 @@ const ThemeContextProvider: React.FC<Props> = ({theme, children, as}) => {
                 eventFormat: 'universal-analytics',
                 ...theme.analytics,
             },
+            colorValues: colors,
             dimensions: {
                 ...dimensions,
                 ...sanitizeDimensions(theme.dimensions),
@@ -139,19 +139,24 @@ const ThemeContextProvider: React.FC<Props> = ({theme, children, as}) => {
             useHrefDecorator: theme.useHrefDecorator ?? useDefaultHrefDecorator,
             useId: theme.useId,
         };
-    }, [theme, isDarkModeEnabled]);
+    }, [colors, theme, isDarkModeEnabled]);
 
     // Define the same colors in css variables as rgb components, to allow applying alpha aftherwards. See utils/color.tsx
-    const rawColors = Object.fromEntries(
-        Object.entries(colors).map(([colorName, colorValue]) => {
-            let rawColorValue = '';
-            if (colorValue.startsWith('#')) {
-                const [r, g, b] = fromHexToRgb(colorValue);
-                rawColorValue = `${r}, ${g}, ${b}`;
-            }
-            return [colorName, rawColorValue];
-        })
-    ) as Colors;
+    const rawColors = React.useMemo(
+        () =>
+            Object.fromEntries(
+                Object.entries(colors).map(([colorName, colorValue]) => {
+                    let rawColorValue = '';
+                    if (colorValue.startsWith('#')) {
+                        const [r, g, b] = fromHexToRgb(colorValue);
+                        rawColorValue = `${r}, ${g}, ${b}`;
+                    }
+                    return [colorName, rawColorValue];
+                })
+            ) as Colors,
+        [colors]
+    );
+
     const themeVars = assignInlineVars(vars, {
         colors,
         rawColors,

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import type {RegionCode} from './utils/region-code';
 import type {Locale} from './utils/locale';
-import type {Skin, SkinName, TextPresetsConfig} from './skins/types';
+import type {Colors, Skin, SkinName, TextPresetsConfig} from './skins/types';
 import type {TrackingEvent} from './utils/types';
 
 export type ThemeTexts = Readonly<typeof TEXTS_ES>;
@@ -372,6 +372,7 @@ export type Theme = {
     };
     // TODO: rename this props to navigationBarHeight (or something similar) in next major
     dimensions: {headerMobileHeight: number; headerDesktopHeight: number};
+    colorValues: Colors;
     textPresets: TextPresetsConfig;
     Link: LinkComponent;
     isDarkMode: boolean;


### PR DESCRIPTION
https://jira.tid.es/browse/WEB-1781

This way we can access color information without using `getCssVarValue`. This is useful when we need to use the color outside a CSS context, for example to send it to the bridge, use it as an API param...