### PR TITLE
fix(Table): avoid rendering row actions twice in jsdom

### DIFF
--- a/src/__tests__/table-test.tsx
+++ b/src/__tests__/table-test.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import {render, screen} from '@testing-library/react';
+import {ThemeContextProvider, Table, IconLightningRegular} from '..';
+import {makeTheme} from './test-utils';
+import userEvent from '@testing-library/user-event';
+
+test('Row actions in collapsed-rows mode are accessible', async () => {
+    const firstActionClickSpy = jest.fn();
+    const secondActionClickSpy = jest.fn();
+    render(
+        <ThemeContextProvider theme={makeTheme()}>
+            <Table
+                responsive="collapse-rows"
+                content={[
+                    {
+                        cells: ['Slice of pizza'],
+                        actions: [
+                            {Icon: IconLightningRegular, onPress: firstActionClickSpy, label: 'action 1'},
+                            {Icon: IconLightningRegular, onPress: secondActionClickSpy, label: 'action 2'},
+                        ],
+                    },
+                ]}
+            />
+        </ThemeContextProvider>
+    );
+
+    await userEvent.click(await screen.findByRole('button', {name: 'action 1'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'action 2'}));
+
+    expect(firstActionClickSpy).toHaveBeenCalledTimes(1);
+    expect(secondActionClickSpy).toHaveBeenCalledTimes(1);
+});

--- a/src/table.css.ts
+++ b/src/table.css.ts
@@ -279,6 +279,7 @@ globalStyle(`${hiddenHeadersInMobile} thead tr`, {
 
 // In collapse-rows mode, we don't render actions as a table cell in mobile
 globalStyle(`${collapsedRowsInMobile} ${actionsTableCell}`, {
+    display: 'block',
     '@media': {
         [mq.tabletOrSmaller]: {
             display: 'none',
@@ -288,9 +289,10 @@ globalStyle(`${collapsedRowsInMobile} ${actionsTableCell}`, {
 
 // In collapse-rows mode, we don't render top actions in desktop
 globalStyle(`${collapsedRowsInMobile} ${topActions}`, {
+    display: 'none',
     '@media': {
-        [mq.desktopOrBigger]: {
-            display: 'none',
+        [mq.tabletOrSmaller]: {
+            display: 'block',
         },
     },
 });

--- a/src/table.css.ts
+++ b/src/table.css.ts
@@ -279,7 +279,6 @@ globalStyle(`${hiddenHeadersInMobile} thead tr`, {
 
 // In collapse-rows mode, we don't render actions as a table cell in mobile
 globalStyle(`${collapsedRowsInMobile} ${actionsTableCell}`, {
-    display: 'block',
     '@media': {
         [mq.tabletOrSmaller]: {
             display: 'none',


### PR DESCRIPTION
When executing an unit test we don't have a viewport, so media queries are not valid there. This was causing row actions to be rendered twice when using collapsed-rows mode