### PR TITLE
fix(Select): onChange was called twice and there was an empty option in iOS

### DIFF
--- a/src/__tests__/select-test.tsx
+++ b/src/__tests__/select-test.tsx
@@ -6,6 +6,8 @@ import ThemeContextProvider from '../theme-context-provider';
 import {makeTheme} from './test-utils';
 
 test('select happy case', async () => {
+    const onChangeSpy = jest.fn();
+
     render(
         <ThemeContextProvider theme={makeTheme()}>
             <Select
@@ -16,6 +18,7 @@ test('select happy case', async () => {
                     {value: 'value2', text: 'text2'},
                     {value: 'value3', text: 'text3'},
                 ]}
+                onChangeValue={onChangeSpy}
             />
         </ThemeContextProvider>
     );
@@ -25,6 +28,9 @@ test('select happy case', async () => {
     expect((screen.getByRole('option', {name: 'text1'}) as HTMLOptionElement).selected).toBe(false);
     expect((screen.getByRole('option', {name: 'text2'}) as HTMLOptionElement).selected).toBe(true);
     expect((screen.getByRole('option', {name: 'text3'}) as HTMLOptionElement).selected).toBe(false);
+
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith('value2');
 });
 
 test('select with controlled value', async () => {


### PR DESCRIPTION
WEB-1953 WEB-1954

We want to support the case of a Select without a selected initial option. To support this we are including an additional default empty `<option>` in the `<select>`.

We style this empty option with `display: none` to avoid this option to appear in the select list when we open it. This works as expected in Chrome:
![Screenshot_20240729_093422_Chrome](https://github.com/user-attachments/assets/6b0b4952-6ef1-45c2-9a80-ecdcd9f5dde1)
But it doesn't work as expected in Safari, and the empty option is shown when the select is open:
![image](https://github.com/user-attachments/assets/7a96af82-e35b-4a90-a962-9263c1ec4d71)

### The fix:
The best fix I've found is using the select's label for that empty option:
![image](https://github.com/user-attachments/assets/1c5a8b49-7d76-4080-85bd-075d455dc340)
And once one of the options is selected, we remove the empty one. So, if we open the select again, the empty option isn't shown anymore (like in Chrome):
![image](https://github.com/user-attachments/assets/befc0032-4709-45c3-9f86-5510eee9d76b)
