### PR TITLE
fix(Buttons): avoid warnings related to change in order of react hooks

### DIFF
--- a/src/button.tsx
+++ b/src/button.tsx
@@ -137,6 +137,20 @@ const renderButtonContent = ({
     const defaultIconSize = small ? styles.iconSize.small : styles.iconSize.default;
     const spinnerSizeRem = small ? styles.spinnerSize.small : styles.spinnerSize.default;
 
+    const buttonElement = renderButtonElement({
+        small,
+        content: children,
+        defaultIconSize,
+        TextContentRenderer,
+    });
+
+    const loadingButtonElement = renderButtonElement({
+        small,
+        content: loadingText,
+        defaultIconSize,
+        TextContentRenderer,
+    });
+
     return (
         <>
             {/* text content */}
@@ -153,12 +167,7 @@ const renderButtonContent = ({
                     </div>
                 )}
                 <div style={{display: 'flex', alignItems: 'baseline'}}>
-                    {renderButtonElement({
-                        small,
-                        content: children,
-                        defaultIconSize,
-                        TextContentRenderer,
-                    })}
+                    {buttonElement}
                     {withChevron && (
                         <div
                             style={{
@@ -197,12 +206,7 @@ const renderButtonContent = ({
                         : undefined
                 }
             >
-                {renderButtonElement({
-                    small,
-                    content: loadingText,
-                    defaultIconSize,
-                    TextContentRenderer,
-                })}
+                {loadingButtonElement}
             </div>
 
             {/* loading content */}
@@ -231,16 +235,7 @@ const renderButtonContent = ({
                         }}
                     />
                 )}
-                {loadingText ? (
-                    <Box paddingLeft={8}>
-                        {renderButtonElement({
-                            small,
-                            content: loadingText,
-                            defaultIconSize,
-                            TextContentRenderer,
-                        })}
-                    </Box>
-                ) : null}
+                {loadingText ? <Box paddingLeft={8}>{loadingButtonElement}</Box> : null}
             </div>
         </>
     );


### PR DESCRIPTION
If loadingText was empty and then it's changed to a non-empty string, the browser will complain because of a change in the order of hooks.

This happens because the `TextContentRenderer` function calls `useTheme()`. The issue is that one of the calls to `TextContentRenderer` was conditional: it was called only when loadingText is truthy. This causes the hook to be called more times if loadingText was falsy and suddenly changes to a truthy value.