### PR TITLE
chore(tests): add workaround for unstable PhoneNumberField tests

### DIFF
--- a/src/__acceptance_tests__/input-fields-acceptance-test.tsx
+++ b/src/__acceptance_tests__/input-fields-acceptance-test.tsx
@@ -173,6 +173,12 @@ test.each(STORY_TYPES)('PhoneNumberField (%s)', async (storyType) => {
 
     const field = await screen.findByLabelText('Label');
 
+    // TODO: https://jira.tid.es/browse/WEB-2047
+    // phonenumberlib is loaded lazily, and if we start typing before the lib is fully loaded,
+    // the test becomes unstable and the final value in the field may be wrong. As a workaround
+    // we wait some time before typing anything into the field
+    await new Promise((r) => setTimeout(r, 100));
+
     await clearAndType(page, field, '654834455');
     expect(await getValue(field)).toBe('654 83 44 55');
 

--- a/src/__screenshot_tests__/input-fields-screenshot-test.tsx
+++ b/src/__screenshot_tests__/input-fields-screenshot-test.tsx
@@ -497,6 +497,12 @@ test.each`
     const fieldWrapper = await screen.findByTestId('phone-number-field');
     const field = await screen.findByLabelText('Label');
 
+    // TODO: https://jira.tid.es/browse/WEB-2047
+    // phonenumberlib is loaded lazily, and if we start typing before the lib is fully loaded,
+    // the test becomes unstable and the final value in the field may be wrong. As a workaround
+    // we wait some time before typing anything into the field
+    await new Promise((r) => setTimeout(r, 100));
+
     await field.click({clickCount: 3});
     await field.type(number);
 


### PR DESCRIPTION
More context in the issue: https://jira.tid.es/browse/WEB-2047