### PR TITLE
chore(Storybook): fix hover color in top bar controls

### DIFF
--- a/.storybook/storybook-manager-theme.js
+++ b/.storybook/storybook-manager-theme.js
@@ -28,6 +28,7 @@ export const createStorybookTheme = (skinName) => {
         // Toolbar default and active colors
         barTextColor: colors.textSecondary,
         barSelectedColor: colors.primary,
+        barHoverColor: colors.brand,
 
         // UI
         appBg: '#ffffff',


### PR DESCRIPTION
Top bar controls was not using the correct brand color for each brand

Before
![image](https://github.com/user-attachments/assets/2cbc415e-1aeb-42ec-868d-44db9c04daea)

After
![image](https://github.com/user-attachments/assets/7476a125-f51e-497c-988b-cd535ea6837d)
