### PR TITLE
feat(Spinner): improve a11y

### DIFF
--- a/src/__tests__/spinner-test.tsx
+++ b/src/__tests__/spinner-test.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import {Spinner} from '..';
+import {render, screen} from '@testing-library/react';
+import ThemeContextProvider from '../theme-context-provider';
+import {makeTheme} from './test-utils';
+
+test('spinner is accessible', () => {
+    render(
+        <ThemeContextProvider theme={makeTheme()}>
+            <Spinner />
+        </ThemeContextProvider>
+    );
+
+    const spinner = screen.getByRole('progressbar', {name: 'Cargando'});
+
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveAttribute('aria-busy');
+});
+
+test('spinner with role presentation is accessible', () => {
+    render(
+        <ThemeContextProvider theme={makeTheme()}>
+            <Spinner rolePresentation />
+        </ThemeContextProvider>
+    );
+
+    const spinner = screen.getByRole('progressbar');
+
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveAttribute('aria-busy');
+});

--- a/src/spinner.tsx
+++ b/src/spinner.tsx
@@ -31,7 +31,9 @@ const Spinner = ({color, delay = '500ms', size = 24, style, rolePresentation}: P
                 className={styles.spinnerIos}
                 height={size}
                 style={{...style}}
-                role="img"
+                role="progressbar"
+                aria-live="polite"
+                aria-busy
                 viewBox="0 0 30 30"
                 width={size}
             >
@@ -85,7 +87,9 @@ const Spinner = ({color, delay = '500ms', size = 24, style, rolePresentation}: P
                 className={styles.spinnerDefault}
                 height={size}
                 style={{...style}}
-                role="img"
+                role="progressbar"
+                aria-live="polite"
+                aria-busy
                 viewBox="0 0 66 66"
                 width={size}
             >


### PR DESCRIPTION
- `role = "progressbar"`: I've found some examples online where spinner is represented as a indeterminate progress bar. For example, [Material does this](https://m2.material.io/components/progress-indicators):

![image](https://github.com/user-attachments/assets/70a6908f-52ba-4646-8976-4ec21dec6f3e)

![image](https://github.com/user-attachments/assets/ad33b8d2-cf0f-4586-a35c-4a305048b141)

- `aria-polite`: we don't need changes announcements to be assertive.

- `aria-busy`: to express that content is being loaded:
![image](https://github.com/user-attachments/assets/e0378615-a03c-46fd-aa39-7481a8cc2812)

