### PR TITLE
feat(Form): Disable autofocus on error for some fields on iOS

### DIFF
--- a/src/__tests__/form-test.tsx
+++ b/src/__tests__/form-test.tsx
@@ -310,7 +310,7 @@ test('Disabling a field removes the error state and disabled fields are not subm
 });
 
 test.each`
-    platform     | element             | expectedFocus
+    platform     | type                | expectedFocus
     ${'ios'}     | ${'date'}           | ${false}
     ${'ios'}     | ${'datetime-local'} | ${false}
     ${'ios'}     | ${'month'}          | ${false}
@@ -321,18 +321,18 @@ test.each`
     ${'android'} | ${'month'}          | ${true}
     ${'android'} | ${'select'}         | ${true}
     ${'android'} | ${'text'}           | ${true}
-`('autofocus on error - $platform $element $expectedFocus', async ({platform, element, expectedFocus}) => {
+`('autofocus on error - $platform $type $expectedFocus', async ({platform, type, expectedFocus}) => {
     const FormComponent = () => {
         return (
             <ThemeContextProvider theme={makeTheme({platformOverrides: {platform}})}>
                 <Form onSubmit={() => {}}>
-                    {element === 'date' && <DateField label="Field" name="field" />}
-                    {element === 'datetime-local' && <DateTimeField label="Field" name="field" />}
-                    {element === 'month' && <MonthField label="Field" name="field" />}
-                    {element === 'select' && (
+                    {type === 'date' && <DateField label="Field" name="field" />}
+                    {type === 'datetime-local' && <DateTimeField label="Field" name="field" />}
+                    {type === 'month' && <MonthField label="Field" name="field" />}
+                    {type === 'select' && (
                         <Select name="field" label="Field" options={[{value: '1', text: '1'}]} />
                     )}
-                    {element === 'text' && <TextField label="Field" name="field" />}
+                    {type === 'text' && <TextField label="Field" name="field" />}
                     <ButtonPrimary submit>Submit</ButtonPrimary>
                 </Form>
             </ThemeContextProvider>

--- a/src/__tests__/form-test.tsx
+++ b/src/__tests__/form-test.tsx
@@ -12,6 +12,7 @@ import {
     DateField,
     DateTimeField,
     Select,
+    MonthField,
 } from '..';
 import ThemeContextProvider from '../theme-context-provider';
 import {makeTheme} from './test-utils';
@@ -327,7 +328,7 @@ test.each`
                 <Form onSubmit={() => {}}>
                     {element === 'date' && <DateField label="Field" name="field" />}
                     {element === 'datetime-local' && <DateTimeField label="Field" name="field" />}
-                    {element === 'month' && <DateField label="Field" name="field" />}
+                    {element === 'month' && <MonthField label="Field" name="field" />}
                     {element === 'select' && (
                         <Select name="field" label="Field" options={[{value: '1', text: '1'}]} />
                     )}

--- a/src/__tests__/form-test.tsx
+++ b/src/__tests__/form-test.tsx
@@ -308,7 +308,7 @@ test('Disabling a field removes the error state and disabled fields are not subm
     );
 });
 
-test.only.each`
+test.each`
     platform     | element             | expectedFocus
     ${'ios'}     | ${'date'}           | ${false}
     ${'ios'}     | ${'datetime-local'} | ${false}

--- a/src/utils/platform.tsx
+++ b/src/utils/platform.tsx
@@ -21,10 +21,19 @@ export const isRunningAcceptanceTest = (platformOverrides: Theme['platformOverri
 
 const isEdgeOrIE = Boolean(typeof self !== 'undefined' && (self as any).MSStream);
 
-export const isAndroid = (platformOverrides: Theme['platformOverrides']): boolean =>
-    getUserAgent(platformOverrides).toLowerCase().includes('android') && !isEdgeOrIE;
+export const isAndroid = (platformOverrides: Theme['platformOverrides']): boolean => {
+    if (platformOverrides.platform === 'android') {
+        return true;
+    }
+
+    return getUserAgent(platformOverrides).toLowerCase().includes('android') && !isEdgeOrIE;
+};
 
 export const isIos = (platformOverrides: Theme['platformOverrides']): boolean => {
+    if (platformOverrides.platform === 'ios') {
+        return true;
+    }
+
     // IE and Edge mobile browsers includes Android and iPhone in the user agent
     if (/iPad|iPhone|iPod/.test(getUserAgent(platformOverrides)) && !isEdgeOrIE) {
         return true;


### PR DESCRIPTION
Fields that are excluded from autofocus on error in iOS because the focus action opens the picker/selector

* date
* datetime-local
* month
* select

Note: scroll to element not affected


A simple unit test that covers these scenarios has been added but you can be manually test this using playroom with a snippet like:
```jsx
<Form>
  <Stack space={16}>
    <Select
      name="field"
      label="field"
      options={[{ value: "x", text: "x" }]}
    />
    <ButtonPrimary submit>Submit</ButtonPrimary>
  </Stack>
</Form>
```
and opening the preview in an iphone