### PR TITLE
fix(Drawer): missing css value for transform

### DIFF
--- a/src/drawer.css.ts
+++ b/src/drawer.css.ts
@@ -59,7 +59,7 @@ export const scrollableSection = style([
 ]);
 
 export const open = style({
-    transform: '',
+    transform: 'initial',
 });
 
 export const closed = style({


### PR DESCRIPTION
screenshot reported by Vivo devs:
![image](https://github.com/user-attachments/assets/2eff69fd-0cf2-44fa-902d-b9b2283d628e)
