### PR TITLE
feat(Touchable): add aria-current support

### DIFF
--- a/src/touchable.tsx
+++ b/src/touchable.tsx
@@ -33,7 +33,7 @@ interface CommonProps {
     'aria-selected'?: 'true' | 'false' | boolean;
     'aria-labelledby'?: string;
     'aria-live'?: 'polite' | 'off' | 'assertive';
-    'aria-current'?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false' | boolean;
+    'aria-current'?: React.AriaAttributes['aria-current'];
     /** IMPORTANT: try to avoid using role="link" with onPress and first consider other alternatives like to/href + onNavigate */
     role?: string;
     type?: 'button' | 'submit';

--- a/src/touchable.tsx
+++ b/src/touchable.tsx
@@ -33,6 +33,7 @@ interface CommonProps {
     'aria-selected'?: 'true' | 'false' | boolean;
     'aria-labelledby'?: string;
     'aria-live'?: 'polite' | 'off' | 'assertive';
+    'aria-current'?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false' | boolean;
     /** IMPORTANT: try to avoid using role="link" with onPress and first consider other alternatives like to/href + onNavigate */
     role?: string;
     type?: 'button' | 'submit';
@@ -117,6 +118,7 @@ const RawTouchable = React.forwardRef<TouchableElement, TouchableProps>((props, 
         'aria-hidden': props['aria-hidden'],
         'aria-selected': props['aria-selected'],
         'aria-live': props['aria-live'],
+        'aria-current': props['aria-current'],
         tabIndex: props.tabIndex,
         ...getPrefixedDataAttributes(props.dataAttributes, 'Touchable'),
     };


### PR DESCRIPTION
WEB-2149

Adding minimal support just to the Touchable component. Further implementations of the prop in components built on top of Touchable is left to a later PR (cc/ @wyunreal).

Playroom demo: 

https://github.com/user-attachments/assets/b04f4153-14f4-4fc0-9c94-1004ff379863

