### PR TITLE
feat(Row): add tabIndex prop

### DIFF
--- a/src/list.tsx
+++ b/src/list.tsx
@@ -106,7 +106,7 @@ export const Content = ({
     const isInverse = useIsInverseOrMediaVariant();
     const numTextLines = [headline, title, subtitle, description, extra].filter(Boolean).length;
     const centerY = numTextLines === 1;
-    
+
     return (
         <div className={styles.content} id={labelId}>
             {asset && (
@@ -380,7 +380,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
         dataAttributes,
         right,
         'aria-label': ariaLabelProp,
-        tabIndex
+        tabIndex,
     } = props;
 
     const [headlineText, setHeadlineText] = React.useState<string>('');

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -56,6 +56,7 @@ interface CommonProps {
     'aria-label'?: string;
     right?: Right;
     danger?: boolean;
+    autoFocus?: boolean;
 }
 
 const renderRight = (right: Right, centerY: boolean) => {
@@ -101,6 +102,7 @@ export const Content = ({
     labelId,
     disabled,
     control,
+    autoFocus = false
 }: ContentProps): JSX.Element => {
     const isInverse = useIsInverseOrMediaVariant();
     const numTextLines = [headline, title, subtitle, description, extra].filter(Boolean).length;
@@ -379,6 +381,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
         dataAttributes,
         right,
         'aria-label': ariaLabelProp,
+        autoFocus
     } = props;
 
     const [headlineText, setHeadlineText] = React.useState<string>('');
@@ -407,6 +410,12 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
     const hasControl = hasControlProps(props);
     const isInteractive = !!props.onPress || !!props.href || !!props.to;
     const hasChevron = hasControl ? false : withChevron ?? isInteractive;
+    const focusableRef = React.useRef<HTMLSelectElement | HTMLDivElement>(null);
+        React.useEffect(() => {
+            if (autoFocus && focusableRef.current) {
+                focusableRef.current.focus();
+            }
+        }, [autoFocus]);
 
     const interactiveProps = {
         href: props.href,
@@ -460,13 +469,14 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
             labelId={contentProps?.labelId}
             disabled={disabled}
             withChevron={hasChevron}
+            autoFocus={autoFocus}
         />
     );
 
     if (isInteractive && !hasControl) {
         return (
             <BaseTouchable
-                ref={ref}
+                ref={focusableRef}
                 className={classNames(styles.rowContent, {
                     [styles.touchableBackground]: hasHoverDefault,
                     [styles.touchableBackgroundInverse]: hasHoverInverse,

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -102,14 +102,19 @@ export const Content = ({
     labelId,
     disabled,
     control,
-    autoFocus = false
+    autoFocus,
 }: ContentProps): JSX.Element => {
     const isInverse = useIsInverseOrMediaVariant();
     const numTextLines = [headline, title, subtitle, description, extra].filter(Boolean).length;
     const centerY = numTextLines === 1;
-
+    const focusableRef = React.useRef<HTMLInputElement>(null);
+    React.useEffect(() => {
+        if (autoFocus && focusableRef.current) {
+            focusableRef.current.focus();
+        }
+    }, [autoFocus, focusableRef]);
     return (
-        <div className={styles.content} id={labelId}>
+        <div className={styles.content} id={labelId} ref={focusableRef}>
             {asset && (
                 <div
                     className={classNames(styles.assetContainer, {
@@ -381,7 +386,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
         dataAttributes,
         right,
         'aria-label': ariaLabelProp,
-        autoFocus
+        autoFocus,
     } = props;
 
     const [headlineText, setHeadlineText] = React.useState<string>('');
@@ -410,12 +415,6 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
     const hasControl = hasControlProps(props);
     const isInteractive = !!props.onPress || !!props.href || !!props.to;
     const hasChevron = hasControl ? false : withChevron ?? isInteractive;
-    const focusableRef = React.useRef<HTMLSelectElement | HTMLDivElement>(null);
-        React.useEffect(() => {
-            if (autoFocus && focusableRef.current) {
-                focusableRef.current.focus();
-            }
-        }, [autoFocus]);
 
     const interactiveProps = {
         href: props.href,
@@ -435,6 +434,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
 
     const renderContent = (contentProps?: {control?: React.ReactNode; labelId?: string}) => (
         <Content
+            autoFocus={autoFocus}
             asset={asset}
             headline={headline}
             headlineRef={(node) => {
@@ -469,14 +469,13 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
             labelId={contentProps?.labelId}
             disabled={disabled}
             withChevron={hasChevron}
-            autoFocus={autoFocus}
         />
     );
 
     if (isInteractive && !hasControl) {
         return (
             <BaseTouchable
-                ref={focusableRef}
+                ref={ref}
                 className={classNames(styles.rowContent, {
                     [styles.touchableBackground]: hasHoverDefault,
                     [styles.touchableBackgroundInverse]: hasHoverInverse,

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -479,6 +479,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
                 dataAttributes={dataAttributes}
                 disabled={disabled}
                 aria-label={ariaLabel}
+                tabIndex={tabIndex}
             >
                 <Box paddingX={16} aria-hidden={!!props.to || !!props.href || undefined}>
                     {renderContent()}
@@ -502,6 +503,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
                     [styles.touchableBackgroundInverse]: hasHoverInverse,
                 })}
                 aria-label={ariaLabel}
+                tabIndex={tabIndex}
             >
                 {renderContent({labelId: titleId})}
             </BaseTouchable>
@@ -577,6 +579,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
                               <Box paddingX={16}>{controlElement}</Box>
                           </Stack>
                       )}
+                      
                   />
               )
             : renderRowWithSingleControl(

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -579,7 +579,6 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
                               <Box paddingX={16}>{controlElement}</Box>
                           </Stack>
                       )}
-                      
                   />
               )
             : renderRowWithSingleControl(

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -56,7 +56,7 @@ interface CommonProps {
     'aria-label'?: string;
     right?: Right;
     danger?: boolean;
-    autoFocus?: boolean;
+    tabIndex?: number;
 }
 
 const renderRight = (right: Right, centerY: boolean) => {
@@ -102,19 +102,13 @@ export const Content = ({
     labelId,
     disabled,
     control,
-    autoFocus,
 }: ContentProps): JSX.Element => {
     const isInverse = useIsInverseOrMediaVariant();
     const numTextLines = [headline, title, subtitle, description, extra].filter(Boolean).length;
     const centerY = numTextLines === 1;
-    const focusableRef = React.useRef<HTMLInputElement>(null);
-    React.useEffect(() => {
-        if (autoFocus && focusableRef.current) {
-            focusableRef.current.focus();
-        }
-    }, [autoFocus, focusableRef]);
+  
     return (
-        <div className={styles.content} id={labelId} ref={focusableRef}>
+        <div className={styles.content} id={labelId} >
             {asset && (
                 <div
                     className={classNames(styles.assetContainer, {
@@ -386,7 +380,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
         dataAttributes,
         right,
         'aria-label': ariaLabelProp,
-        autoFocus,
+        tabIndex
     } = props;
 
     const [headlineText, setHeadlineText] = React.useState<string>('');
@@ -434,7 +428,6 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
 
     const renderContent = (contentProps?: {control?: React.ReactNode; labelId?: string}) => (
         <Content
-            autoFocus={autoFocus}
             asset={asset}
             headline={headline}
             headlineRef={(node) => {
@@ -651,6 +644,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
             role={role}
             {...getPrefixedDataAttributes(dataAttributes)}
             ref={ref as React.Ref<HTMLDivElement>}
+            tabIndex={tabIndex}
         >
             <div aria-hidden={hasCustomAriaLabel}>{renderContent()}</div>
             {hasCustomAriaLabel && (

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -105,7 +105,8 @@ export const Content = ({
 }: ContentProps): JSX.Element => {
     const isInverse = useIsInverseOrMediaVariant();
     const numTextLines = [headline, title, subtitle, description, extra].filter(Boolean).length;
-    const centerY = numTextLines === 1;    
+    const centerY = numTextLines === 1;
+    
     return (
         <div className={styles.content} id={labelId}>
             {asset && (

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -105,10 +105,9 @@ export const Content = ({
 }: ContentProps): JSX.Element => {
     const isInverse = useIsInverseOrMediaVariant();
     const numTextLines = [headline, title, subtitle, description, extra].filter(Boolean).length;
-    const centerY = numTextLines === 1;
-  
+    const centerY = numTextLines === 1;    
     return (
-        <div className={styles.content} id={labelId} >
+        <div className={styles.content} id={labelId}>
             {asset && (
                 <div
                     className={classNames(styles.assetContainer, {


### PR DESCRIPTION
O2DE-7083

Related with accessibility, when expanding a list, the focus should move to the first element of the expanded list and that's why the tabIndex prop is needed.

Locally tested:
[Screen_recording_20250311_084555.webm](https://github.com/user-attachments/assets/c1d569c4-d2ad-4a6e-b72b-63e097e63ce8)

