### PR TITLE
feat(Row,BoxedRow): allow overriding touchable role

### DIFF
--- a/src/__tests__/list-test.tsx
+++ b/src/__tests__/list-test.tsx
@@ -81,6 +81,27 @@ test('Row as a button', async () => {
     expect(spy).toHaveBeenCalled();
 });
 
+test('Row, keeping its listitem role, containing a button reporting link role', async () => {
+    const spy = jest.fn();
+    render(
+        <ThemeContextProvider theme={makeTheme()}>
+            <RowList>
+                <Row title="Title" onPress={spy} touchableRole="link" />
+            </RowList>
+        </ThemeContextProvider>
+    );
+
+    const rowDiv = screen.getByRole('listitem');
+    expect(rowDiv).toBeInTheDocument();
+
+    const button = screen.getByRole('link', {name: 'Title'});
+    expect(button).toBeInTheDocument();
+    expect(rowDiv).toContainElement(button);
+
+    await userEvent.click(button);
+    expect(spy).toHaveBeenCalled();
+});
+
 test('Row with switch', async () => {
     const spyOnChange = jest.fn();
 
@@ -292,6 +313,27 @@ test('Row list with iconButton', async () => {
     await userEvent.click(iconButton);
     expect(iconButtonOnPressSpy).toHaveBeenCalledTimes(1);
     expect(logEventSpy).toHaveBeenCalledWith({name: 'icon-button-tracking-event'});
+});
+
+test('BoxedRow, keeping its listitem role, containing a button reporting link role', async () => {
+    const spy = jest.fn();
+    render(
+        <ThemeContextProvider theme={makeTheme()}>
+            <BoxedRowList>
+                <BoxedRow title="Title" onPress={spy} touchableRole="link" />
+            </BoxedRowList>
+        </ThemeContextProvider>
+    );
+
+    const rowDiv = screen.getByRole('listitem');
+    expect(rowDiv).toBeInTheDocument();
+
+    const button = screen.getByRole('link', {name: 'Title'});
+    expect(button).toBeInTheDocument();
+    expect(rowDiv).toContainElement(button);
+
+    await userEvent.click(button);
+    expect(spy).toHaveBeenCalled();
 });
 
 test('Text content is read by screen readers in the right order in Rows with link', () => {

--- a/src/__tests__/list-test.tsx
+++ b/src/__tests__/list-test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {RowList, Row, BoxedRowList, BoxedRow} from '../list';
 import {RadioGroup} from '../radio-button';
-import {screen, render, waitFor} from '@testing-library/react';
+import {screen, render, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
     ButtonPrimary,
@@ -327,9 +327,8 @@ test('BoxedRow, keeping its listitem role, containing a button reporting link ro
     const rowDiv = screen.getByRole('listitem');
     expect(rowDiv).toBeInTheDocument();
 
-    const button = screen.getByRole('link', {name: 'Title'});
+    const button = within(rowDiv).getByRole('link', {name: 'Title'});
     expect(button).toBeInTheDocument();
-    expect(rowDiv).toContainElement(button);
 
     await userEvent.click(button);
     expect(spy).toHaveBeenCalled();

--- a/src/__tests__/list-test.tsx
+++ b/src/__tests__/list-test.tsx
@@ -94,9 +94,8 @@ test('Row, keeping its listitem role, containing a button reporting link role', 
     const rowDiv = screen.getByRole('listitem');
     expect(rowDiv).toBeInTheDocument();
 
-    const button = screen.getByRole('link', {name: 'Title'});
+    const button = within(rowDiv).getByRole('link', {name: 'Title'});
     expect(button).toBeInTheDocument();
-    expect(rowDiv).toContainElement(button);
 
     await userEvent.click(button);
     expect(spy).toHaveBeenCalled();

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -478,7 +478,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
                     [styles.pointer]: !disabled,
                 })}
                 {...interactiveProps}
-                role={touchableRole ?? role}
+                role={touchableRole}
                 dataAttributes={dataAttributes}
                 disabled={disabled}
                 aria-label={ariaLabel}
@@ -500,7 +500,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
             <BaseTouchable
                 disabled={disabled}
                 {...interactiveProps}
-                role={touchableRole ?? role}
+                role={touchableRole}
                 className={classNames(styles.dualActionLeft, {
                     [styles.touchableBackground]: hasHoverDefault,
                     [styles.touchableBackgroundInverse]: hasHoverInverse,

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -646,7 +646,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
     return (
         <div
             className={classNames(styles.rowContent, styles.rowContentPadding)}
-            role={touchableRole ?? role}
+            role={role}
             {...getPrefixedDataAttributes(dataAttributes)}
             ref={ref as React.Ref<HTMLDivElement>}
             tabIndex={tabIndex}
@@ -735,17 +735,20 @@ type BoxedRowProps = ExclusifyUnion<
 > &
     CommonBoxedRowProps;
 
-export const BoxedRow = React.forwardRef<HTMLDivElement, BoxedRowProps>(({dataAttributes, ...props}, ref) => (
-    <InternalBoxed
-        overflow="visible"
-        className={styles.boxed}
-        variant={props.isInverse ? 'inverse' : 'default'}
-        ref={ref}
-        dataAttributes={{'component-name': 'BoxedRow', testid: 'BoxedRow', ...dataAttributes}}
-    >
-        <RowContent {...props} />
-    </InternalBoxed>
-));
+export const BoxedRow = React.forwardRef<HTMLDivElement, BoxedRowProps>(
+    ({dataAttributes, role = 'listitem', ...props}, ref) => (
+        <InternalBoxed
+            overflow="visible"
+            className={styles.boxed}
+            variant={props.isInverse ? 'inverse' : 'default'}
+            ref={ref}
+            role={role}
+            dataAttributes={{'component-name': 'BoxedRow', testid: 'BoxedRow', ...dataAttributes}}
+        >
+            <RowContent {...props} />
+        </InternalBoxed>
+    )
+);
 
 type BoxedRowListProps = {
     children: React.ReactNode;

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -735,20 +735,17 @@ type BoxedRowProps = ExclusifyUnion<
 > &
     CommonBoxedRowProps;
 
-export const BoxedRow = React.forwardRef<HTMLDivElement, BoxedRowProps>(
-    ({dataAttributes, role = 'listitem', ...props}, ref) => (
-        <InternalBoxed
-            overflow="visible"
-            className={styles.boxed}
-            variant={props.isInverse ? 'inverse' : 'default'}
-            ref={ref}
-            role={role}
-            dataAttributes={{'component-name': 'BoxedRow', testid: 'BoxedRow', ...dataAttributes}}
-        >
-            <RowContent {...props} />
-        </InternalBoxed>
-    )
-);
+export const BoxedRow = React.forwardRef<HTMLDivElement, BoxedRowProps>(({dataAttributes, ...props}, ref) => (
+    <InternalBoxed
+        overflow="visible"
+        className={styles.boxed}
+        variant={props.isInverse ? 'inverse' : 'default'}
+        ref={ref}
+        dataAttributes={{'component-name': 'BoxedRow', testid: 'BoxedRow', ...dataAttributes}}
+    >
+        <RowContent {...props} />
+    </InternalBoxed>
+));
 
 type BoxedRowListProps = {
     children: React.ReactNode;

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -49,6 +49,7 @@ interface CommonProps {
     asset?: React.ReactNode;
     badge?: boolean | number;
     role?: string;
+    touchableRole?: string;
     extra?: React.ReactNode;
     dataAttributes?: DataAttributes;
     disabled?: boolean;
@@ -375,6 +376,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
         danger,
         badge,
         role,
+        touchableRole,
         extra,
         withChevron,
         dataAttributes,
@@ -426,7 +428,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
 
     const [isChecked, toggle] = useControlState(props.switch || props.checkbox || {});
 
-    const renderContent = (contentProps?: {control?: React.ReactNode; labelId?: string}) => (
+    const renderContent = (contentProps?: {control?: React.ReactNode; labelId?: string; role?: string}) => (
         <Content
             asset={asset}
             headline={headline}
@@ -453,6 +455,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
                 }
             }}
             control={contentProps?.control}
+            role={contentProps?.role}
             extra={extra}
             extraRef={(node) => {
                 if (node) {
@@ -475,14 +478,14 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
                     [styles.pointer]: !disabled,
                 })}
                 {...interactiveProps}
-                role={role}
+                role={touchableRole ?? role}
                 dataAttributes={dataAttributes}
                 disabled={disabled}
                 aria-label={ariaLabel}
                 tabIndex={tabIndex}
             >
                 <Box paddingX={16} aria-hidden={!!props.to || !!props.href || undefined}>
-                    {renderContent()}
+                    {renderContent({role})}
                 </Box>
             </BaseTouchable>
         );
@@ -497,7 +500,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
             <BaseTouchable
                 disabled={disabled}
                 {...interactiveProps}
-                role={role}
+                role={touchableRole ?? role}
                 className={classNames(styles.dualActionLeft, {
                     [styles.touchableBackground]: hasHoverDefault,
                     [styles.touchableBackgroundInverse]: hasHoverInverse,
@@ -505,7 +508,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
                 aria-label={ariaLabel}
                 tabIndex={tabIndex}
             >
-                {renderContent({labelId: titleId})}
+                {renderContent({labelId: titleId, role})}
             </BaseTouchable>
 
             <div className={styles.dualActionDivider} />
@@ -643,12 +646,12 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
     return (
         <div
             className={classNames(styles.rowContent, styles.rowContentPadding)}
-            role={role}
+            role={touchableRole ?? role}
             {...getPrefixedDataAttributes(dataAttributes)}
             ref={ref as React.Ref<HTMLDivElement>}
             tabIndex={tabIndex}
         >
-            <div aria-hidden={hasCustomAriaLabel}>{renderContent()}</div>
+            <div aria-hidden={hasCustomAriaLabel}>{renderContent({role})}</div>
             {hasCustomAriaLabel && (
                 <ScreenReaderOnly>
                     <span>{props['aria-label']}</span>


### PR DESCRIPTION
Changes:

- On row and boxed row components, a new prop is added to customize the touchable role.
- if this prop is NOT used, the touchable continues getting the role prop is passed, else, the touchable role is used.
- This prop is not used when the row contains a control.