### PR TITLE
feat(RowList, BoxedRowList, Stack): O2DE-7699 RowList with aria-live and aria-atomic attributes

### DIFF
--- a/src/__stories__/list-story.tsx
+++ b/src/__stories__/list-story.tsx
@@ -51,10 +51,6 @@ export default {
             ],
             control: {type: 'select'},
         },
-        'aria-live': {
-            options: ['off', 'polite', 'assertive'],
-            control: {type: 'select'},
-        },
     },
     parameters: {
         fullScreen: true,
@@ -76,14 +72,14 @@ type Args = {
     disabled: boolean;
     danger: boolean;
     overInverse: boolean;
-    'aria-live': 'off' | 'polite' | 'assertive';
-    'aria-atomic': boolean;
 };
 
 const Template: StoryComponent<
     Args & {
         boxed?: boolean;
         inverse?: boolean;
+        'aria-live'?: 'off' | 'polite' | 'assertive';
+        'aria-atomic'?: boolean;
     }
 > = ({
     boxed,
@@ -451,13 +447,25 @@ const defaultArgs = {
     disabled: false,
     danger: false,
     overInverse: false,
-    'aria-live': 'off' as const,
-    'aria-atomic': false as const,
 };
 
-export const RowListStory: StoryComponent<Args> = (args) => <Template {...args} />;
+export const RowListStory: StoryComponent<
+    Args & {
+        'aria-live': 'off' | 'polite' | 'assertive';
+        'aria-atomic': boolean;
+    }
+> = (args) => <Template {...args} />;
 RowListStory.storyName = 'RowList';
-RowListStory.args = defaultArgs;
+RowListStory.args = {...defaultArgs, 'aria-live': 'off', 'aria-atomic': false};
+RowListStory.argTypes = {
+    'aria-live': {
+        control: {type: 'select'},
+        options: ['off', 'polite', 'assertive'],
+    },
+    'aria-atomic': {
+        control: {type: 'boolean'},
+    },
+};
 
 export const BoxedRowListStory: StoryComponent<Args & {inverse: boolean}> = (args) => (
     <Template boxed {...args} />

--- a/src/__stories__/list-story.tsx
+++ b/src/__stories__/list-story.tsx
@@ -74,7 +74,14 @@ type Args = {
     overInverse: boolean;
 };
 
-const Template: StoryComponent<Args & {boxed?: boolean; inverse?: boolean}> = ({
+const Template: StoryComponent<
+    Args & {
+        boxed?: boolean;
+        inverse?: boolean;
+        'aria-live'?: 'off' | 'polite' | 'assertive';
+        'aria-atomic'?: boolean;
+    }
+> = ({
     boxed,
     headline,
     title,
@@ -91,6 +98,8 @@ const Template: StoryComponent<Args & {boxed?: boolean; inverse?: boolean}> = ({
     overInverse,
     inverse,
     danger,
+    'aria-live': ariaLive,
+    'aria-atomic': ariaAtomic,
 }) => {
     const extraContent = extra ? <Placeholder height={56} /> : undefined;
 
@@ -105,26 +114,45 @@ const Template: StoryComponent<Args & {boxed?: boolean; inverse?: boolean}> = ({
                 controlProps = {href: 'https://example.org', newTab: true, right: null}; // right null removes the chevron
                 break;
             case 'switch':
-                controlProps = {switch: {defaultValue: true, onChange: () => {}}};
+                controlProps = {
+                    switch: {
+                        defaultValue: true,
+                        onChange: () => {},
+                    },
+                };
                 break;
             case 'switch and onPress':
                 controlProps = {
-                    switch: {defaultValue: true, onChange: () => {}},
+                    switch: {
+                        defaultValue: true,
+                        onChange: () => {},
+                    },
                     onPress,
                 };
                 break;
             case 'checkbox':
-                controlProps = {checkbox: {defaultValue: true, onChange: () => {}}};
+                controlProps = {
+                    checkbox: {
+                        defaultValue: true,
+                        onChange: () => {},
+                    },
+                };
                 break;
             case 'checkbox and onPress':
                 controlProps = {
-                    checkbox: {defaultValue: true, onChange: () => {}},
+                    checkbox: {
+                        defaultValue: true,
+                        onChange: () => {},
+                    },
                     onPress,
                 };
                 break;
             case 'checkbox with custom element':
                 controlProps = {
-                    checkbox: {defaultValue: true, onChange: () => {}},
+                    checkbox: {
+                        defaultValue: true,
+                        onChange: () => {},
+                    },
                     right: () => (
                         <div style={{display: 'flex', alignItems: 'center', height: '100%'}}>
                             <div style={{width: 32, height: 32, borderRadius: '50%', background: 'pink'}} />
@@ -229,7 +257,7 @@ const Template: StoryComponent<Args & {boxed?: boolean; inverse?: boolean}> = ({
 
     let row = 1;
     const list = (
-        <ListComponent dataAttributes={{testid: 'list'}}>
+        <ListComponent dataAttributes={{testid: 'list'}} aria-live={ariaLive} aria-atomic={ariaAtomic}>
             <RowComponent
                 headline={headline}
                 title={title}
@@ -421,9 +449,23 @@ const defaultArgs = {
     overInverse: false,
 };
 
-export const RowListStory: StoryComponent<Args> = (args) => <Template {...args} />;
+export const RowListStory: StoryComponent<
+    Args & {
+        'aria-live': 'off' | 'polite' | 'assertive';
+        'aria-atomic': boolean;
+    }
+> = (args) => <Template {...args} />;
 RowListStory.storyName = 'RowList';
-RowListStory.args = defaultArgs;
+RowListStory.args = {...defaultArgs, 'aria-live': 'off', 'aria-atomic': false};
+RowListStory.argTypes = {
+    'aria-live': {
+        control: {type: 'select'},
+        options: ['off', 'polite', 'assertive'],
+    },
+    'aria-atomic': {
+        control: {type: 'boolean'},
+    },
+};
 
 export const BoxedRowListStory: StoryComponent<Args & {inverse: boolean}> = (args) => (
     <Template boxed {...args} />

--- a/src/__stories__/list-story.tsx
+++ b/src/__stories__/list-story.tsx
@@ -51,6 +51,10 @@ export default {
             ],
             control: {type: 'select'},
         },
+        'aria-live': {
+            options: ['off', 'polite', 'assertive'],
+            control: {type: 'select'},
+        },
     },
     parameters: {
         fullScreen: true,
@@ -72,14 +76,14 @@ type Args = {
     disabled: boolean;
     danger: boolean;
     overInverse: boolean;
+    'aria-live': 'off' | 'polite' | 'assertive';
+    'aria-atomic': boolean;
 };
 
 const Template: StoryComponent<
     Args & {
         boxed?: boolean;
         inverse?: boolean;
-        'aria-live'?: 'off' | 'polite' | 'assertive';
-        'aria-atomic'?: boolean;
     }
 > = ({
     boxed,
@@ -447,25 +451,13 @@ const defaultArgs = {
     disabled: false,
     danger: false,
     overInverse: false,
+    'aria-live': 'off' as const,
+    'aria-atomic': false as const,
 };
 
-export const RowListStory: StoryComponent<
-    Args & {
-        'aria-live': 'off' | 'polite' | 'assertive';
-        'aria-atomic': boolean;
-    }
-> = (args) => <Template {...args} />;
+export const RowListStory: StoryComponent<Args> = (args) => <Template {...args} />;
 RowListStory.storyName = 'RowList';
-RowListStory.args = {...defaultArgs, 'aria-live': 'off', 'aria-atomic': false};
-RowListStory.argTypes = {
-    'aria-live': {
-        control: {type: 'select'},
-        options: ['off', 'polite', 'assertive'],
-    },
-    'aria-atomic': {
-        control: {type: 'boolean'},
-    },
-};
+RowListStory.args = defaultArgs;
 
 export const BoxedRowListStory: StoryComponent<Args & {inverse: boolean}> = (args) => (
     <Template boxed {...args} />

--- a/src/__stories__/stack-story.tsx
+++ b/src/__stories__/stack-story.tsx
@@ -34,17 +34,11 @@ const ComponentThatReturnsNullComponent = () => <Null />;
 
 type Args = {
     space: string;
-    'aria-live': 'off' | 'polite' | 'assertive';
-    'aria-atomic': boolean;
 };
 
-export const Default: StoryComponent<Args> = ({space, 'aria-live': ariaLive, 'aria-atomic': ariaAtomic}) => (
+export const Default: StoryComponent<Args> = ({space}) => (
     <div style={{height: '100vh'}}>
-        <Stack
-            space={(Number.isInteger(+space) ? +space : space) as never}
-            aria-live={ariaLive}
-            aria-atomic={ariaAtomic}
-        >
+        <Stack space={(Number.isInteger(+space) ? +space : space) as never}>
             <ComponentThatReturnsNullComponent />
             <Row>One</Row>
             {null}
@@ -60,16 +54,7 @@ export const Default: StoryComponent<Args> = ({space, 'aria-live': ariaLive, 'ar
 );
 
 Default.storyName = 'Stack';
+
 Default.args = {
     space: '32',
-    'aria-live': 'off' as const,
-    'aria-atomic': false as const,
-};
-Default.argTypes = {
-    space: {control: {type: 'select'}},
-    'aria-live': {
-        options: ['off', 'polite', 'assertive'],
-        control: {type: 'select'},
-    },
-    'aria-atomic': {control: {type: 'boolean'}},
 };

--- a/src/__stories__/stack-story.tsx
+++ b/src/__stories__/stack-story.tsx
@@ -34,11 +34,17 @@ const ComponentThatReturnsNullComponent = () => <Null />;
 
 type Args = {
     space: string;
+    'aria-live': 'off' | 'polite' | 'assertive';
+    'aria-atomic': boolean;
 };
 
-export const Default: StoryComponent<Args> = ({space}) => (
+export const Default: StoryComponent<Args> = ({space, 'aria-live': ariaLive, 'aria-atomic': ariaAtomic}) => (
     <div style={{height: '100vh'}}>
-        <Stack space={(Number.isInteger(+space) ? +space : space) as never}>
+        <Stack
+            space={(Number.isInteger(+space) ? +space : space) as never}
+            aria-live={ariaLive}
+            aria-atomic={ariaAtomic}
+        >
             <ComponentThatReturnsNullComponent />
             <Row>One</Row>
             {null}
@@ -54,7 +60,16 @@ export const Default: StoryComponent<Args> = ({space}) => (
 );
 
 Default.storyName = 'Stack';
-
 Default.args = {
     space: '32',
+    'aria-live': 'off' as const,
+    'aria-atomic': false as const,
+};
+Default.argTypes = {
+    space: {control: {type: 'select'}},
+    'aria-live': {
+        options: ['off', 'polite', 'assertive'],
+        control: {type: 'select'},
+    },
+    'aria-atomic': {control: {type: 'boolean'}},
 };

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -677,6 +677,8 @@ type RowListProps = {
     children: React.ReactNode;
     ariaLabelledby?: string;
     role?: string;
+    'aria-live'?: 'polite' | 'off' | 'assertive';
+    'aria-atomic'?: boolean;
     dataAttributes?: DataAttributes;
 };
 
@@ -684,14 +686,19 @@ export const RowList = ({
     children,
     ariaLabelledby,
     role = 'list',
+    'aria-live': ariaLive = 'off',
+    'aria-atomic': ariaAtomic = false,
     dataAttributes,
 }: RowListProps): JSX.Element => {
     const childrenContent = React.Children.toArray(children).filter(Boolean);
     const lastIndex = childrenContent.length - 1;
+
     return (
         <div
             role={role}
             aria-labelledby={ariaLabelledby}
+            aria-live={ariaLive}
+            aria-atomic={ariaAtomic}
             {...getPrefixedDataAttributes(dataAttributes, 'RowList')}
         >
             {childrenContent.map((child, index) => (
@@ -751,6 +758,8 @@ type BoxedRowListProps = {
     children: React.ReactNode;
     ariaLabelledby?: string;
     role?: string;
+    'aria-live'?: 'polite' | 'off' | 'assertive';
+    'aria-atomic'?: boolean;
     dataAttributes?: DataAttributes;
 };
 

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -758,8 +758,6 @@ type BoxedRowListProps = {
     children: React.ReactNode;
     ariaLabelledby?: string;
     role?: string;
-    'aria-live'?: 'polite' | 'off' | 'assertive';
-    'aria-atomic'?: boolean;
     dataAttributes?: DataAttributes;
 };
 

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -673,14 +673,17 @@ export const Row = React.forwardRef<TouchableElement, RowContentProps>(
     )
 );
 
+type CommonAccessibilityProps = {
+    'aria-live'?: 'polite' | 'off' | 'assertive';
+    'aria-atomic'?: boolean;
+};
+
 type RowListProps = {
     children: React.ReactNode;
     ariaLabelledby?: string;
     role?: string;
-    'aria-live'?: 'polite' | 'off' | 'assertive';
-    'aria-atomic'?: boolean;
     dataAttributes?: DataAttributes;
-};
+} & CommonAccessibilityProps;
 
 export const RowList = ({
     children,
@@ -718,8 +721,8 @@ export const RowList = ({
 // danger + isInverse is not allowed
 type CommonBoxedRowProps =
     | {
-          danger: true;
           isInverse?: false;
+          danger: true;
       }
     | {
           isInverse?: boolean;
@@ -758,21 +761,23 @@ type BoxedRowListProps = {
     children: React.ReactNode;
     ariaLabelledby?: string;
     role?: string;
-    'aria-live'?: 'polite' | 'off' | 'assertive';
-    'aria-atomic'?: boolean;
     dataAttributes?: DataAttributes;
-};
+} & CommonAccessibilityProps;
 
 export const BoxedRowList = ({
     children,
     ariaLabelledby,
     role = 'list',
     dataAttributes,
+    'aria-live': ariaLive = 'off',
+    'aria-atomic': ariaAtomic = false,
 }: BoxedRowListProps): JSX.Element => (
     <Stack
         space={16}
         role={role}
         aria-labelledby={ariaLabelledby}
+        aria-live={ariaLive}
+        aria-atomic={ariaAtomic}
         dataAttributes={{'component-name': 'BoxedRowList', testid: 'BoxedRowList', ...dataAttributes}}
     >
         {children}

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -673,17 +673,14 @@ export const Row = React.forwardRef<TouchableElement, RowContentProps>(
     )
 );
 
-type CommonAccessibilityProps = {
-    'aria-live'?: 'polite' | 'off' | 'assertive';
-    'aria-atomic'?: boolean;
-};
-
 type RowListProps = {
     children: React.ReactNode;
     ariaLabelledby?: string;
     role?: string;
+    'aria-live'?: 'polite' | 'off' | 'assertive';
+    'aria-atomic'?: boolean;
     dataAttributes?: DataAttributes;
-} & CommonAccessibilityProps;
+};
 
 export const RowList = ({
     children,
@@ -721,8 +718,8 @@ export const RowList = ({
 // danger + isInverse is not allowed
 type CommonBoxedRowProps =
     | {
-          isInverse?: false;
           danger: true;
+          isInverse?: false;
       }
     | {
           isInverse?: boolean;
@@ -761,23 +758,21 @@ type BoxedRowListProps = {
     children: React.ReactNode;
     ariaLabelledby?: string;
     role?: string;
+    'aria-live'?: 'polite' | 'off' | 'assertive';
+    'aria-atomic'?: boolean;
     dataAttributes?: DataAttributes;
-} & CommonAccessibilityProps;
+};
 
 export const BoxedRowList = ({
     children,
     ariaLabelledby,
     role = 'list',
     dataAttributes,
-    'aria-live': ariaLive = 'off',
-    'aria-atomic': ariaAtomic = false,
 }: BoxedRowListProps): JSX.Element => (
     <Stack
         space={16}
         role={role}
         aria-labelledby={ariaLabelledby}
-        aria-live={ariaLive}
-        aria-atomic={ariaAtomic}
         dataAttributes={{'component-name': 'BoxedRowList', testid: 'BoxedRowList', ...dataAttributes}}
     >
         {children}

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -758,6 +758,8 @@ type BoxedRowListProps = {
     children: React.ReactNode;
     ariaLabelledby?: string;
     role?: string;
+    'aria-live'?: 'polite' | 'off' | 'assertive';
+    'aria-atomic'?: boolean;
     dataAttributes?: DataAttributes;
 };
 

--- a/src/stack.tsx
+++ b/src/stack.tsx
@@ -39,6 +39,8 @@ type Props = {
     className?: string;
     role?: string;
     'aria-labelledby'?: string;
+    'aria-live'?: 'polite' | 'off' | 'assertive';
+    'aria-atomic'?: boolean;
     dataAttributes?: DataAttributes;
 };
 
@@ -48,6 +50,8 @@ const Stack = ({
     children,
     role,
     'aria-labelledby': ariaLabelledby,
+    'aria-live': ariaLive,
+    'aria-atomic': ariaAtomic,
     dataAttributes,
 }: Props): JSX.Element => {
     const isFlexStack = typeof space === 'string';
@@ -58,6 +62,8 @@ const Stack = ({
             style={applyCssVars(calcInlineVars(space))}
             role={role}
             aria-labelledby={ariaLabelledby}
+            aria-live={ariaLive}
+            aria-atomic={ariaAtomic}
             {...getPrefixedDataAttributes(dataAttributes)}
         >
             {React.Children.map(children, (child) => (

--- a/src/stack.tsx
+++ b/src/stack.tsx
@@ -39,8 +39,6 @@ type Props = {
     className?: string;
     role?: string;
     'aria-labelledby'?: string;
-    'aria-live'?: 'polite' | 'off' | 'assertive';
-    'aria-atomic'?: boolean;
     dataAttributes?: DataAttributes;
 };
 
@@ -50,8 +48,6 @@ const Stack = ({
     children,
     role,
     'aria-labelledby': ariaLabelledby,
-    'aria-live': ariaLive,
-    'aria-atomic': ariaAtomic,
     dataAttributes,
 }: Props): JSX.Element => {
     const isFlexStack = typeof space === 'string';
@@ -62,8 +58,6 @@ const Stack = ({
             style={applyCssVars(calcInlineVars(space))}
             role={role}
             aria-labelledby={ariaLabelledby}
-            aria-live={ariaLive}
-            aria-atomic={ariaAtomic}
             {...getPrefixedDataAttributes(dataAttributes)}
         >
             {React.Children.map(children, (child) => (


### PR DESCRIPTION
Introduce `aria-live` and `aria-atomic` for `RowList`, `BoxedRowList` and `Stack`
`Stack` is needed because `BoxedRowList` wraps it as its first child.

In case we consider this is way too much, an alternative version exposing the props only for `RowList` is available [here](https://github.com/Telefonica/mistica-web/pull/1378).