### PR TITLE
fix(Radio): update tabIndex logic when no radio is selected

### DIFF
--- a/src/__tests__/radio-button-test.tsx
+++ b/src/__tests__/radio-button-test.tsx
@@ -297,3 +297,45 @@ test('Radio onClick event is not propagated', async () => {
 
     expect(onPressHandler).not.toHaveBeenCalled();
 });
+
+test('Radiogroup with no radio selected gets focus on first radio using TAB navigation', async () => {
+    render(
+        <ThemeContextProvider theme={makeTheme()}>
+            <ButtonPrimary onPress={() => {}}>Focus me first</ButtonPrimary>
+            <RadioGroup name="radio-group" aria-labelledby="label">
+                <RadioButton value="banana" />
+                <RadioButton value="apple" />
+            </RadioGroup>
+        </ThemeContextProvider>
+    );
+
+    const button = screen.getByRole('button', {name: 'Focus me first'});
+    await userEvent.click(button);
+    expect(button).toHaveFocus();
+
+    await userEvent.tab();
+
+    const radios = screen.getAllByRole('radio');
+    expect(radios[0]).toHaveFocus();
+});
+
+test('Radiogroup with selected radio gets focus on selected radio using TAB navigation', async () => {
+    render(
+        <ThemeContextProvider theme={makeTheme()}>
+            <ButtonPrimary onPress={() => {}}>Focus me first</ButtonPrimary>
+            <RadioGroup name="radio-group" aria-labelledby="label" defaultValue="apple">
+                <RadioButton value="banana" />
+                <RadioButton value="apple" />
+            </RadioGroup>
+        </ThemeContextProvider>
+    );
+
+    const button = screen.getByRole('button', {name: 'Focus me first'});
+    await userEvent.click(button);
+    expect(button).toHaveFocus();
+
+    await userEvent.tab();
+
+    const radios = screen.getAllByRole('radio');
+    expect(radios[1]).toHaveFocus();
+});


### PR DESCRIPTION
WEB-2262

Can be verified in [this playroom](https://mistica-3ujvm8jm3-flows-projects-65bb050e.vercel.app/playroom#?code=N4Igxg9gJgpiBcIA8AhArgFwxAdgBQCcBLAWwEMCBPAAl0JgGcGBeYACgEprmA%2Ba4AL4CeAYQA2RMAGtqJGEgD06LHWLkqPADo4kAJTJQiEAOIEIaAA5ac1anogB3ADJEGGa7dv2H1DEQxiMMyaIChkOOFkIdQEBkYAamRiaEEhAEaREdEKHp7evv6BwSAAghYWgdGxhhCJyakgZOWVINQ52l4Kuo4ubtaK%2BjWm5lbaIAA0IBgAFjByDAgA2iAAshAAbq4YFCAAupMORFAzC-CLAMwAbAAMuwJAA)