### PR TITLE
feat(Cards): Card ecosystem evolution

### DIFF
--- a/src/card.css.ts
+++ b/src/card.css.ts
@@ -207,7 +207,7 @@ export const mediaCardContent = style([
         position: 'relative',
         paddingX: 16,
         paddingTop: 16,
-        paddingBottom: 24,
+        paddingBottom: 32,
         flexDirection: 'column',
         justifyContent: 'space-between',
     }),
@@ -218,7 +218,6 @@ export const mediaCardContent = style([
                 paddingLeft: 24,
                 paddingRight: 24,
                 paddingTop: 24,
-                paddingBottom: 32,
             },
         },
     },
@@ -279,7 +278,8 @@ export const dataCard = style([
         display: 'flex',
         flex: 1,
         position: 'relative',
-        paddingY: 24,
+        paddingTop: 24,
+        paddingBottom: 32,
         paddingX: 16,
         flexDirection: 'column',
         width: '100%',
@@ -289,7 +289,6 @@ export const dataCard = style([
         '@media': {
             [mq.desktopOrBigger]: {
                 paddingTop: 32,
-                paddingBottom: 32,
                 paddingLeft: 24,
                 paddingRight: 24,
             },
@@ -368,7 +367,7 @@ export const displayCardBackground = style({
     zIndex: 0,
 });
 
-export const displayCardContentWrapper = sprinkles({paddingX: 24, paddingBottom: 24});
+export const displayCardContentWrapper = sprinkles({paddingX: 24, paddingBottom: 32});
 
 export const displayCardGradient = style([
     sprinkles({paddingTop: 40}),
@@ -379,7 +378,7 @@ export const displayCardGradient = style([
 
 export const posterCardContentWrapper = sprinkles({
     paddingX: {mobile: 16, desktop: 24},
-    paddingBottom: 24,
+    paddingBottom: 32,
 });
 
 const aspectRatio = createVar();


### PR DESCRIPTION
* [x] Change the bottom padding of the display, data, media, and poster cards to 32px (currently 24px)
	* [x] display
	* [x] data
	* [x] media
	* [x] poster
* [ ] Change the spacing between the tag and the content in the poster cards to 8px (currently 16px)
* [ ] Allow actions in the poster and display media cards
* [ ] Add the footer to all card variants
* [ ] Allow top actions when there's a video
* [ ] Expand the definition of custom background color to all cards (currently only in the poster)
* [ ] Allow all cards to be rendered in either their inverse or default variant via config
* [ ] Deprecate the highlighted card and allow configuring the position of the media element in the media card; the option to set image fit will be removed in this new definition
* [ ] Allow aligning the slot to the top or bottom when the card’s height exceeds the height defined by its content
* [ ] Affects other components
* [ ] Allow alignment of the button group to the left or right to achieve aligned actions in the footer
* [ ] Add the media variant to actions https://github.com/Telefonica/mistica-design/pull/2232 
* [ ] Enable all cards to have the same content elements: pretitle, title, subtitle, and description