### PR TITLE
fix(Row,BoxedRow): fix ScreenReaderOnly position for iOS VoiceOver in informative lists using aria-label

### DIFF
--- a/src/list.css.ts
+++ b/src/list.css.ts
@@ -63,6 +63,7 @@ export const rowContent = style([
         padding: 0,
         display: 'block',
         height: '100%',
+        position: 'relative',
     }),
     {
         selectors: {
@@ -77,6 +78,13 @@ export const rowContent = style([
         },
     },
 ]);
+
+// Position the ScreenReaderOnly text in a natural place inside the row, this makes VoiceOver "focus" appear in a good position
+export const screenReaderOnly = style({
+    position: 'absolute',
+    top: 16,
+    left: 16,
+});
 
 export const rowContentPadding = sprinkles({
     paddingX: 16,

--- a/src/list.tsx
+++ b/src/list.tsx
@@ -663,7 +663,7 @@ const RowContent = React.forwardRef<TouchableElement, RowContentProps>((props, r
         >
             <div aria-hidden={hasCustomAriaLabel}>{renderContent({role})}</div>
             {hasCustomAriaLabel && (
-                <ScreenReaderOnly>
+                <ScreenReaderOnly className={styles.screenReaderOnly}>
                     <span>{props['aria-label']}</span>
                 </ScreenReaderOnly>
             )}


### PR DESCRIPTION
https://jira.tid.es/browse/WEB-2167

https://github.com/user-attachments/assets/86fde2fb-5e9e-4e98-843e-ef9bbfdee9ec

