### PR TITLE
fix(ci): update vercel-action to main branch

### DIFF
--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -19,7 +19,7 @@ jobs:
               with:
                   persist-credentials: false
 
-            - uses: amondnet/vercel-action@v41.1.4 # Pinned because v42 fails with "Error: Provided path ./ is not absolute"
+            - uses: amondnet/vercel-action@master
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }} # needed to allow comments on prs
                   vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required
@@ -27,4 +27,4 @@ jobs:
                   vercel-project-id: ${{ secrets.MISTICA_WEB_VERCEL_PROJECT_ID}} #Required
                   vercel-project-name: mistica-web # Not requried by the docs, but the action fails if not specified. See https://github.com/amondnet/vercel-action/issues/30#issuecomment-678608424
                   vercel-args: '--prod'
-                  working-directory: ./
+                  working-directory: ${{ github.workspace }}

--- a/.github/workflows/deploy-pull-requests.yml
+++ b/.github/workflows/deploy-pull-requests.yml
@@ -24,7 +24,7 @@ jobs:
             - run: sed -i 's/yarn vercel-build/yarn vercel-preview-build/' vercel.json
               shell: bash
 
-            - uses: amondnet/vercel-action@v41.1.4 # Pinned because v42 fails with "Error: Provided path ./ is not absolute"
+            - uses: amondnet/vercel-action@master
               id: vercel-deploy # identifier to reference this step
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }} # needed to allow comments on prs
@@ -32,4 +32,4 @@ jobs:
                   vercel-org-id: ${{ secrets.MISTICA_WEB_VERCEL_ORG_ID}} # required
                   vercel-project-id: ${{ secrets.MISTICA_WEB_VERCEL_PROJECT_ID}} # required
                   vercel-project-name: mistica-web # not required by the docs, but the action fails if not specified. See https://github.com/amondnet/vercel-action/issues/30#issuecomment-678608424
-                  working-directory: ./
+                  working-directory: ${{ github.workspace }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ community.d.ts
 # SonarQube scan
 .scannerwork
 *storybook.log
+.env*.local

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -67,6 +67,7 @@ const config: StorybookConfig = {
     },
 
     core: {
+        allowedHosts: ['host.docker.internal'],
         disableWhatsNewNotifications: true,
         builder: {
             name: '@storybook/builder-vite',


### PR DESCRIPTION
## Summary
- Updates `amondnet/vercel-action` from pinned `v41.1.4` to `main` branch in both deploy workflows
- The pin was originally due to v42 failing with "Error: Provided path ./ is not absolute", which is resolved in this PR
- Deployments now use API