### PR TITLE
chore: add dev server launch configuration

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.0.1",
+    "configurations": [
+        {
+            "name": "Storybook",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": ["storybook"],
+            "port": 6006
+        },
+        {
+            "name": "Playroom",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": ["playroom"],
+            "port": 9000
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/launch.json` with dev server configurations for Storybook and Playroom
- Enables Claude Code's `preview_start` tool to launch servers by name

## Configurations

| Server | Command | Port |
|--------|---------|------|
| Storybook | `yarn storybook` | 6006 |
| Playroom | `yarn playroom` | 9000 |

## Test plan

- [ ] Run `preview_start` with name `"Storybook"` and verify it starts on port 6006
- [ ] Run `preview_start` with name `"Playroom"` and verify it starts on port 9000

🤖 Generated with [Claude Code](https://claude.com/claude-code)