### PR TITLE
fix(Sheet): make close button clickable on iOS

### DIFF
--- a/src/sheet-common.tsx
+++ b/src/sheet-common.tsx
@@ -247,6 +247,14 @@ const Sheet = React.forwardRef<HTMLDivElement, SheetProps>(({onClose, children, 
                              * the content in order to be able to drag the sheet
                              */}
                             <div className={styles.sheetTopDraggingArea} />
+                            <div className={styles.dismissButton}>
+                                <IconButton
+                                    small={isTabletOrSmaller}
+                                    onPress={closeModal}
+                                    aria-label={texts.modalClose || t(tokens.modalClose)}
+                                    Icon={IconCloseRegular}
+                                />
+                            </div>
 
                             <section
                                 role="dialog"
@@ -263,14 +271,6 @@ const Sheet = React.forwardRef<HTMLDivElement, SheetProps>(({onClose, children, 
                                     : children}
                                 <div className={styles.handleContainer}>
                                     <div className={styles.handleBar} />
-                                </div>
-                                <div className={styles.dismissButton}>
-                                    <IconButton
-                                        small={isTabletOrSmaller}
-                                        onPress={closeModal}
-                                        aria-label={texts.modalClose || t(tokens.modalClose)}
-                                        Icon={IconCloseRegular}
-                                    />
                                 </div>
                             </section>
                         </div>

--- a/src/sheet-common.tsx
+++ b/src/sheet-common.tsx
@@ -247,15 +247,6 @@ const Sheet = React.forwardRef<HTMLDivElement, SheetProps>(({onClose, children, 
                              * the content in order to be able to drag the sheet
                              */}
                             <div className={styles.sheetTopDraggingArea} />
-                            <div className={styles.dismissButton}>
-                                <IconButton
-                                    small={isTabletOrSmaller}
-                                    onPress={closeModal}
-                                    aria-label={texts.modalClose || t(tokens.modalClose)}
-                                    Icon={IconCloseRegular}
-                                />
-                            </div>
-
                             <section
                                 role="dialog"
                                 aria-modal="true"
@@ -273,6 +264,14 @@ const Sheet = React.forwardRef<HTMLDivElement, SheetProps>(({onClose, children, 
                                     <div className={styles.handleBar} />
                                 </div>
                             </section>
+                            <div className={styles.dismissButton}>
+                                <IconButton
+                                    small={isTabletOrSmaller}
+                                    onPress={closeModal}
+                                    aria-label={texts.modalClose || t(tokens.modalClose)}
+                                    Icon={IconCloseRegular}
+                                />
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Move the Sheet dismiss (close) button outside the scrollable `<section>` so it is not clipped by the parent's `overflowY: auto`.
- On iOS, the close button was rendered outside the visible scroll area and therefore not clickable. Hoisting it to the sibling container (alongside `sheetTopDraggingArea`) restores tap interaction without affecting visual placement.
