### PR TITLE
feat(Chore): MisticaAI update doc to improve code generation

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -1,6 +1,6 @@
 # Components Reference
 
-All components are imported from `@telefonica/mistica`.
+All components are imported from `@telefonica/mistica`. Before using any component, you should **always** read the definition .d.ts files located in `node_modules` so you have all the props and JSDoc context.
 
 ```tsx
 import {ButtonPrimary, Stack, Text2, ...} from '@telefonica/mistica';

--- a/doc/layout.md
+++ b/doc/layout.md
@@ -11,6 +11,7 @@
     - [around](#around)
     - [evenly](#evenly)
     - [nesting](#nesting)
+    - [Grow](#grow)
   - [Align](#align)
   - [Grid / GridItem](#grid--griditem)
   - [NegativeBox](#negativebox)

--- a/doc/layout.md
+++ b/doc/layout.md
@@ -49,13 +49,21 @@ spacing. All padding props accept a numeric value or a responsive object `{mobil
 
 ```tsx
 <Box paddingX={16} paddingY={32}>
-  <Child />
+  <Text2>Example</Text2>
 </Box>
 ```
 
 <img src="./images/layout/box.svg" />
 
 :warning: Do not use `Box` to add external spacings or distribute items, instead use `Stack` or `Inline`.
+
+You can also use Box as a fixed width container:
+
+```tsx
+<Box width={80}>
+  <Text2>Example</Text2>
+</Box>
+```
 
 ## Stack
 
@@ -158,6 +166,41 @@ with a value on the right via `space="between"`:
 
 The outer `Inline` distributes the two groups to opposite ends; the inner `Inline` keeps the icon tightly
 grouped with its label at a fixed gap.
+
+### Grow
+
+Use the `expand` prop to make one or more children of an `Inline` grow to fill the remaining horizontal space.
+It takes the index (or an array of indexes) of the children that should grow. Indexes follow
+`React.Children.toArray` order, so empty nodes (`null`, `false`) are skipped but rendered elements always
+count. You don't wrap the growing child in anything — `Inline` already wraps every child in its own element:
+
+```tsx
+<Inline space={56} alignItems="center" expand={1}>
+  <Text7>4,6</Text7>
+  <InfoRating
+    value={4}
+    icon={{
+      ActiveIcon: IconStarFilled,
+      InactiveIcon: IconStarLight,
+      color: skinVars.colors.textPrimary,
+    }}
+  />
+  <Text3 regular>150 valoraciones</Text3>
+</Inline>
+```
+
+```tsx
+<Inline space={16} alignItems="center" expand={[1, 2]}>
+  <IconTruckRegular size={24} color={skinVars.colors.neutralHigh} />
+  <TextField name="firstName" label="First name" fullWidth />
+  <TextField name="lastName" label="Last name" fullWidth />
+</Inline>
+```
+
+**Common mistakes.** `Inline` wraps each child in its own element, so growing a child by wrapping it in a
+`<div style={{flex: 1}}>` (or `flex-grow`) does nothing useful. Neither does `<Box style={{...}}>` — `Box` has
+no `style` prop, so a flex or width passed that way is silently dropped and the row collapses or overflows its
+container. Reach for `expand` (and `<Box width={N}>` for any fixed sibling) instead.
 
 ## Align
 

--- a/doc/patterns.md
+++ b/doc/patterns.md
@@ -97,6 +97,29 @@ Follow the 24/32/16 rule:
 </Stack>
 ```
 
+### DO: Fill remaining horizontal space with `Inline` `expand`
+
+To make a row child grow into the leftover width next to a fixed-width sibling , use `Inline`'s `expand` prop
+with the index/indexes of the children that should grow. Indexes follow `React.Children.toArray` order.
+
+```tsx
+// ProgressBar fills remaining space
+<Inline space={24} expand={1} alignItems="center">
+  <Icon2GFilled />
+  <ProgressBar progressPercent={30} />
+</Inline>
+```
+
+### DON'T: grow children with raw flex or `style` on `Box`
+
+```tsx
+// ❌ raw flexbox div — breaks; Inline already wraps each child in a div
+<div style={{display: 'flex'}}>
+  <div style={{flex: 1}}>...</div>
+  <div style={{flex: '0 0 394px'}}>...</div>
+</div>
+```
+
 ## Color dos and don'ts
 
 ### DO: Use design tokens

--- a/doc/patterns.md
+++ b/doc/patterns.md
@@ -99,7 +99,7 @@ Follow the 24/32/16 rule:
 
 ### DO: Fill remaining horizontal space with `Inline` `expand`
 
-To make a row child grow into the leftover width next to a fixed-width sibling , use `Inline`'s `expand` prop
+To make a row child grow into the leftover width next to a fixed-width sibling, use `Inline`'s `expand` prop
 with the index/indexes of the children that should grow. Indexes follow `React.Children.toArray` order.
 
 ```tsx


### PR DESCRIPTION
## Introduction

The objective of this task was investigating if we needed new doc to cover the Inline new prop `expanded`. In order to do so we added some new rules to the doc and tested it against the pristine mistica version with JSDoc only.

We tested a single Figma design (iPhone 14 product detail page) **6 times**: 3 runs with the MODIFIED doc folder live and 3 runs with the PRISTINE published `@telefonica/mistica@16.63.1` doc folder swapped in. All 6 iterations were independent fresh `claude -p --permission-mode auto --model claude-opus-4-7` processes of the same prompt — each one read the `mistica-react` skill, called Figma MCP on the root frame and its sub-sections, then wrote a single React component. **Auto-memory was permanently deleted before the runs** (a prior pass was discarded after we found the user's auto-memory already encoded the same rules — that's a confounder).

- Figma design: https://www.figma.com/design/puOwn8pBJCrMYksvXeCiJO/AI-Test---Figma-MCP-2-code?node-id=1-67192

## Summary

Across 6 runs on the same design, **MOD docs produced consistent, idiomatic Mistica layout code; PRI docs produced inconsistent results** — half the time correct, half the time the `<div style={{flex:1}}>` anti-pattern the new rules target. The differentiator was specifically the `Inline expand` API usage and the avoidance of raw flex/style fallbacks, not visual fidelity (both arms render the page faithfully).

### Patterns

- **Same idiomatic Mistica components in every run.** All 6 iterations independently picked up `MainNavigationBar`, `NavigationBreadcrumbs`, `ResponsiveLayout`, `GridLayout`, `Slideshow`, `Image`, `Tag`, `Title1/4`, `Text2/3/7`, `InfoRating`, `RadioGroup`, `BoxedRow`/`BoxedRowList`, `Chip`, `ButtonPrimary`, `TextLink`, `MediaCard`, `Tabs`, `Accordion`/`AccordionItem`, `ProgressBar`, `Box`, `Stack`, `Inline`, `skinVars`, plus the same set of icons.
- **`Inline expand` adoption is the cleanest discriminating signal — 3/3 MOD, 1/3 PRI.** All three MOD runs used `<Inline … expand={N}>` for the rating-distribution rows. Only one of three PRI runs did; the other two fell back to `<div style={{flex:1, …}}>`/`<div style={{flexGrow:1}}>` nested inside an `Inline` — exactly the silent-no-op the new `layout.md` "common mistakes" call-out warns about.
- **`<Box width={N}>` is only triggered by the docs — 6 sites across MOD, 0 sites across PRI.** Every MOD run used `<Box width={80}>` (or `width={90}`) for the fixed label column next to a `ProgressBar`. No PRI run used a `Box width` anywhere — they either inlined `<div style={{width:80, flexShrink:0}}>` or fell back to `space="between"` and let the layout breathe.
- **The model already knows `expand` exists** (it's in `dist/inline.d.ts: expand?: number | ReadonlyArray<number>`, and Mistica is public on GitHub). So PRI isn't a "no knowledge" baseline — the prop is in the typed API surface. The docs aren't teaching the prop; they're putting it (and the worked example) in front of the agent during the task, which is what makes adoption reliable.

### Random failures

Despite identical prompts and identical context, the iterations fail in different places:

- **"Comprados juntos" 3-card row** is rendered slightly differently across runs. Layout primitive choice varies but ends up mostly correct on all 6.
- **Hero gallery**: some runs picked `Slideshow`, one picked `Carousel` (per its own justification of containment). Both are valid Mistica primitives.
- **Accordion default open/closed state** varies — most runs opened all three; PRI_3 left them collapsed.

## Methodology

1. Spawned **3 parallel fresh `claude -p`** subprocesses with the **MODIFIED** doc folder live in `node_modules/@telefonica/mistica/doc/`. Each independently:
   - Read `mistica-react` skill and called Figma MCP on the root frame and sub-sections.
   - Wrote a single React component to its own output directory.
2. Replaced `node_modules/.../doc/` with the **PRISTINE** published `@telefonica/mistica@16.63.1` docs. Repeated with 3 fresh subprocesses. Restored the modified docs afterwards.
3. Each generated `ProductPage.tsx` was mounted in a wrapper `ThemeContextProvider` (Movistar New skin), built with Vite (`base: './'`, no dev server), served on a unique localhost port, and captured by Playwright/Chromium at 1368 px wide, full page, 2× DPR.
4. Per-run rule scan: counted `<Inline`, `expand=`, raw flex-div lines (`<div … flex/flexGrow/flexShrink/flex:N`), `<Box width={`, and inline-style layout hacks (`style={{…}}` excluding `cursor:'pointer'`).

## Iterations

> The reference Figma is the same for all 6 runs:
> https://www.figma.com/design/puOwn8pBJCrMYksvXeCiJO/AI-Test---Figma-MCP-2-code?node-id=1-67192&m=dev

---

### Pair 1 — MOD_1 vs PRI_1

| Modified docs (MOD_1)                                                                                   | Pristine docs (PRI_1)                                                                                   |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| <img src="https://github.com/user-attachments/assets/9ed55d4d-534b-416f-900e-668533b6dc22" width="400"> | <img src="https://github.com/user-attachments/assets/e2193804-94c8-44e4-9864-87ce3e404b5e" width="400"> |

|                                              | MOD_1     | PRI_1                                         |
| -------------------------------------------- | --------- | --------------------------------------------- |
| `<Inline expand={N}>` for rating rows        | ✓ 1 use   | ✓ 1 use (knew `expand` probably from `.d.ts`) |
| Raw `<div … flex/flexGrow/flexShrink>` lines | 0         | 0                                             |
| `<Box width={N}>` for fixed label column     | ✓ 2 sites | 0                                             |
| Inline `style={{…}}`                         | 0         | 0                                             |
| **Rule score (4 signals)**                   | **4 / 4** | **3 / 4** (no `Box width`)                    |

**Net.** Visual tie, both clean code-wise. PRI*1 is the one PRI run that reached for `expand` on its own — likely from the typed API in `dist/inline.d.ts`. It still skipped `<Box width={N}>` for the fixed label column (handled the fixed width implicitly via `Inline space=…`), which only the docs trigger. This pair is the \_best case* for PRI: when the model happens to spelunk the `.d.ts`, it gets close to MOD.

---

### Pair 2 — MOD_2 vs PRI_2

| Modified docs (MOD_2)                                                                                   | Pristine docs (PRI_2)                                                                                   |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| <img src="https://github.com/user-attachments/assets/9a1a4fd8-ab0e-4829-8f4a-f13d81533c83" width="400"> | <img src="https://github.com/user-attachments/assets/48f8842e-bb77-4ecf-a20b-8f78205c45c4" width="400"> |

|                                              | MOD_2     | PRI_2                                                                                                                                                                |
| -------------------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `<Inline expand={N}>` for rating rows        | ✓ 2 uses  | ✗ **0 — fell back to `<div style={{flex:1}}>` anti-pattern**                                                                                                         |
| Raw `<div … flex/flexGrow/flexShrink>` lines | 0         | **3** — `<div style={{width:80, flexShrink:0}}>`, `<div style={{flexGrow:1, minWidth:0}}>`, `<div style={{width:40, flexShrink:0}}>` on the rating-distribution rows |
| `<Box width={N}>` for fixed label column     | ✓ 2 sites | 0                                                                                                                                                                    |
| Inline `style={{…}}`                         | 0         | **3** — same lines as above                                                                                                                                          |
| **Rule score (4 signals)**                   | **4 / 4** | **0 / 4**                                                                                                                                                            |

**Net.** In the rating-distribution row, MOD_2 wrote `<Inline … expand={1}><Box width={80}>…<ProgressBar/></Inline>` and PRI_2 wrote three raw `<div style={{…}}>` wrappers nested inside an `Inline` — the canonical anti-pattern the new `patterns.md` DO/DON'T documents. This is the headline contrast.

---

### Pair 3 — MOD_3 vs PRI_3

| Modified docs (MOD_3)                                                                                   | Pristine docs (PRI_3)                                                                                   |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| <img src="https://github.com/user-attachments/assets/d9e3cbef-f64e-483a-af13-ea2f341e39ab" width="400"> | <img src="https://github.com/user-attachments/assets/ce982f5e-9bc3-4217-bc4a-75314b7f9600" width="400"> |

|                                              | MOD_3     | PRI_3                            |
| -------------------------------------------- | --------- | -------------------------------- |
| `<Inline expand={N}>` for rating rows        | ✓ 1 use   | ✗ **0 — fell back to flex divs** |
| Raw `<div … flex/flexGrow/flexShrink>` lines | 0         | **3**                            |
| `<Box width={N}>` for fixed label column     | ✓ 2 sites | 0                                |
| Inline `style={{…}}`                         | 0         | **4**                            |
| **Rule score (4 signals)**                   | **4 / 4** | **0 / 4**                        |

**Net.** PRI_3 reached for raw flex divs and inline width styles for the rating rows; MOD_3 used the documented `Inline expand` + `Box width` pattern. Visually MOD_3 is slightly worse (its images didn't bundle)

## Results

### Rule-adherence at a glance

Counts across the 6 runs' main `ProductPage.tsx` (`PRI_1` is structured as a full vite app, so its main file is at `src/ProductPage.tsx`):

| Iteration | lines | `<Inline` | `expand=` | rawFlexDivLines | `<Box width={` | style hacks |
| --------- | ----: | --------: | --------: | --------------: | -------------: | ----------: |
| MOD_1     |   501 |        19 |  **1** ✅ |        **0** ✅ |       **2** ✅ |    **0** ✅ |
| MOD_2     |   524 |        18 |  **2** ✅ |        **0** ✅ |       **2** ✅ |    **0** ✅ |
| MOD_3     |   497 |        14 |  **1** ✅ |        **0** ✅ |       **2** ✅ |    **0** ✅ |
| PRI_1     |   395 |        12 |  **1** ✅ |        **0** ✅ |              0 |    **0** ✅ |
| PRI_2     |   469 |        14 |  **0** ❌ |        **3** ❌ |              0 |    **3** ❌ |
| PRI_3     |   603 |        21 |  **0** ❌ |        **3** ❌ |              0 |    **4** ❌ |

| Rule signal                                     | MOD | PRI |
| ----------------------------------------------- | --: | --: |
| `<Inline … expand={N}>` for growing children    | 3/3 | 1/3 |
| Avoids raw `<div … flex/flexGrow/flexShrink>`   | 3/3 | 1/3 |
| Uses `<Box width={N}>` for fixed-width siblings | 3/3 | 0/3 |
| No `style={{…}}` layout hacks                   | 3/3 | 1/3 |

### Run metadata

| run   | duration (min) | total tokens (incl. cache) |
| ----- | -------------: | -------------------------: |
| MOD_1 |           18.0 |                  7,955,293 |
| MOD_2 |           11.4 |                  5,912,631 |
| MOD_3 |           11.3 |                  6,919,185 |
| PRI_1 |           12.9 |                  6,234,771 |
| PRI_2 |            8.9 |                  2,931,614 |
| PRI_3 |           10.2 |                  4,370,949 |

## Conclusions

- **The three new doc rules don't teach the model what `expand` is** — it's in the typed API surface (`dist/inline.d.ts`), but sometimes agents don't read that files. This effect seems to be especially strong when there's doc available through a skill like in mistica.
- **Agents consistently use `expand` prop when doc is available** (3/3 MOD vs 1/3 PRI for `expand`, 0 layout style hacks for MOD vs 7 for PRI), and **small-to-zero on visual fidelity** (both arms render the page faithfully). The benefit is code quality and maintainability, not what an end user sees.
- **`<Box width={N}>` is only used when documented.** 6 sites across MOD, 0 across PRI. The `layout.md` fixed-width example is the trigger. When not documented agents tend to use divs.
- **The "read `.d.ts` first" rule is the structural lever.** It's the one that explains why PRI_1 succeeded — the agent independently spelunked the type definitions and discovered `expand`. Codifying that as default behaviour (which the modified `components.md` does) is what would make PRI behave like MOD. Worth keeping in the docs even though we can't score it from artifacts.
