### PR TITLE
feat(Chore): package mistica-web as a Claude Code plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+    "name": "Mistica Web",
+    "description": "Telefonica's Mistica Design System — React component library skill for building web UIs with @telefonica/mistica.",
+    "version": "1.0.0",
+    "author": {
+        "name": "Telefonica",
+        "email": "cto-apps@telefonica.com"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Telefonica/mistica-web"
+    },
+    "license": "MIT",
+    "keywords": ["react", "design-system", "telefonica", "mistica", "ui", "components"]
+}

--- a/skills/mistica-react/SKILL.md
+++ b/skills/mistica-react/SKILL.md
@@ -5,6 +5,10 @@ description: >
   skill when writing React UI code with @telefonica/mistica, creating pages, layouts, forms, or any user
   interface that should follow Telefonica's design guidelines. Triggers on tasks involving Mistica components,
   Telefonica branding, or when the user mentions Mistica.
+license: MIT
+metadata:
+  author: telefonica
+  version: '1.0.0'
 ---
 
 # Mistica React - Telefonica Design System

--- a/skills/mistica-react/SKILL.md
+++ b/skills/mistica-react/SKILL.md
@@ -1,14 +1,10 @@
 ---
 name: mistica-react
-description:
+description: >
   Build websites and web applications using Telefonica's Mistica design system React components. Use this
   skill when writing React UI code with @telefonica/mistica, creating pages, layouts, forms, or any user
   interface that should follow Telefonica's design guidelines. Triggers on tasks involving Mistica components,
   Telefonica branding, or when the user mentions Mistica.
-license: MIT
-metadata:
-  author: telefonica
-  version: '1.0.0'
 ---
 
 # Mistica React - Telefonica Design System
@@ -39,8 +35,8 @@ npm install @telefonica/mistica
 source of truth and contains critical rules, a quick start guide, component categories, design token overview,
 and step-by-step instructions on which documentation files to read and in what order.
 
-> **Fallback**: If `node_modules/@telefonica/mistica/doc/llms.md` is not available, fetch the equivalent file from the
-> GitHub repository: `https://github.com/Telefonica/mistica-web/blob/master/doc/llms.md`
+> **Fallback**: If `node_modules/@telefonica/mistica/doc/llms.md` is not available, fetch the equivalent file
+> from the GitHub repository: `https://github.com/Telefonica/mistica-web/blob/master/doc/llms.md`
 
 Follow every instruction in `llms.md` exactly, including reading all minimum required docs before generating
 any code.


### PR DESCRIPTION
## Summary

- Add `.claude-plugin/plugin.json` manifest so the repo can be installed as a Claude Code plugin from the marketplace
- Clean up `skills/mistica-react/SKILL.md` frontmatter — removed `license`, `metadata.author`, and `metadata.version` fields (those now live in the plugin manifest where they belong) and kept only `name` and `description` per the standard plugin skill format

## How to install

Once merged, the plugin will be installable in any Claude Code session:

```
/plugin marketplace add Telefonica/mistica-web
/plugin install mistica-web
```

This makes the `mistica-react` skill available as `/mistica-web:mistica-react` for anyone building UIs with `@telefonica/mistica`.

## Test plan

- [ ] Verify `.claude-plugin/plugin.json` is valid JSON with required fields
- [ ] Verify `skills/mistica-react/SKILL.md` frontmatter only has `name` and `description`
- [ ] Test plugin install via `/plugin marketplace add` + `/plugin install` in a Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)