### PR TITLE
chore(Chore): add Codex plugin support via symlink

### DIFF
--- a/plugin/.codex-plugin
+++ b/plugin/.codex-plugin
@@ -1,0 +1,1 @@
+.claude-plugin


### PR DESCRIPTION
## Summary

- Adds `plugin/.codex-plugin` as a symlink pointing to `.claude-plugin`
- Both Claude Code and OpenAI Codex now recognise `plugin/` as a plugin, sharing the same `plugin.json` and `skills/` without duplication

## Test plan

- [ ] Verify `plugin/.codex-plugin/plugin.json` resolves correctly via the symlink
- [ ] Install Codex CLI (`npm i -g @openai/codex`) and run `codex plugin validate ./plugin` once available

🤖 Generated with [Claude Code](https://claude.com/claude-code)