### PR TITLE
feat(Chore): support Cyber community skin in Playroom

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,8 @@ We would love to accept your Pull Requests but please, before starting your deve
   "Chore" as the component name. For allowed types check [lint action](./.github/workflows/ci.yml#L108).
 - PR description: concise summary of the problem and fix, ending with `Ref: <TICKET-ID>` (if there's a jira
   ticket).
-- Always add reviewers `aweell`, `atabel`, `yceballost` and `Marcosld` to every PR.
+- Always add reviewers `aweell`, `atabel`, `yceballost`, `Marcosld`, `AlexandraGallipoliRodrigues` and
+  `brtbrt` to every PR.
 
 ## Bug reports
 

--- a/playroom/components/index.tsx
+++ b/playroom/components/index.tsx
@@ -447,8 +447,6 @@ const PreviewToolsComponent = ({
 
 export const PreviewTools = (props: PreviewToolsProps): JSX.Element | null => {
     const {skinName} = useTheme();
-    // PreviewTools doesn't support skins not listed in themesMap (community skins like Cyber):
-    // render nothing for them
     if (!(skinName in themesMap)) {
         return null;
     }

--- a/playroom/components/index.tsx
+++ b/playroom/components/index.tsx
@@ -244,7 +244,7 @@ type PreviewToolsProps = {
 
 const FLOATING_CONTROLS_ENTER_DURATION = 300;
 
-export const PreviewTools = ({
+const PreviewToolsComponent = ({
     children,
     floating,
     position = 'top-right',
@@ -443,4 +443,14 @@ export const PreviewTools = ({
             </>
         );
     }
+};
+
+export const PreviewTools = (props: PreviewToolsProps): JSX.Element | null => {
+    const {skinName} = useTheme();
+    // PreviewTools doesn't support skins not listed in themesMap (community skins like Cyber):
+    // render nothing for them
+    if (!(skinName in themesMap)) {
+        return null;
+    }
+    return <PreviewToolsComponent {...props} />;
 };

--- a/playroom/frame-component.tsx
+++ b/playroom/frame-component.tsx
@@ -23,6 +23,7 @@ import {
     BLAU_SKIN,
 } from '../src';
 import {Movistar_New as defaultThemeConfig} from './themes';
+import {CYBER_SKIN} from '../src/community';
 
 import type {ThemeConfig} from '../src';
 
@@ -62,6 +63,7 @@ const skinToLang: Record<string, string> = {
     [O2_SKIN]: 'en-GB',
     [O2_NEW_SKIN]: 'en-GB',
     [ESIMFLAG_SKIN]: 'es-ES',
+    [CYBER_SKIN]: 'es-ES',
 };
 
 const App = ({children, skinName}: {children: React.ReactNode; skinName: string}) => {

--- a/playroom/themes.tsx
+++ b/playroom/themes.tsx
@@ -16,6 +16,7 @@ export const O2_New: ThemeConfig = {...themes.O2_New, ...common};
 export const Telefonica: ThemeConfig = {...themes.Telefonica, ...common};
 export const Blau: ThemeConfig = {...themes.Blau, ...common};
 export const Esimflag: ThemeConfig = {...themes.Esimflag, ...common};
+export const Community_Cyber: ThemeConfig = {...themes.Cyber, ...common};
 
 export const Movistar_New_iOS: ThemeConfig = {...Movistar_New, platformOverrides: {platform: 'ios'}};
 export const Vivo_New_iOS: ThemeConfig = {...Vivo_New, platformOverrides: {platform: 'ios'}};
@@ -23,3 +24,4 @@ export const O2_New_iOS: ThemeConfig = {...O2_New, platformOverrides: {platform:
 export const Telefonica_iOS: ThemeConfig = {...Telefonica, platformOverrides: {platform: 'ios'}};
 export const Blau_iOS: ThemeConfig = {...Blau, platformOverrides: {platform: 'ios'}};
 export const Esimflag_iOS: ThemeConfig = {...Esimflag, platformOverrides: {platform: 'ios'}};
+export const Community_Cyber_iOS: ThemeConfig = {...Community_Cyber, platformOverrides: {platform: 'ios'}};


### PR DESCRIPTION
## Summary

Adds support for the Cyber community skin in Playroom, while keeping it out of the PreviewTools component.
Adding future community skins to Playroom requires no PreviewTools changes: anything not in `themesMap` renders null automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)