### PR TITLE
chore(Chore): update reviewer instructions to use team handle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ We would love to accept your Pull Requests but please, before starting your deve
   "Chore" as the component name. For allowed types check [lint action](./.github/workflows/ci.yml#L108).
 - PR description: concise summary of the problem and fix, ending with `Ref: <TICKET-ID>` (if there's a jira
   ticket).
-- Always add reviewers `aweell`, `atabel`, `yceballost` and `Marcosld` to every PR.
+- Always add the `@Telefonica/mistica-web-reviewers` team as reviewer to every PR.
 
 ## Bug reports
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ We would love to accept your Pull Requests but please, before starting your deve
   "Chore" as the component name. For allowed types check [lint action](./.github/workflows/ci.yml#L108).
 - PR description: concise summary of the problem and fix, ending with `Ref: <TICKET-ID>` (if there's a jira
   ticket).
-- Always add the `@Telefonica/mistica-web-reviewers` team as reviewer to every PR.
+- Always add the `@Telefonica/mistica-web-reviewers` team as a reviewer to every PR.
 
 ## Bug reports
 


### PR DESCRIPTION
Replace individual GitHub reviewer usernames with the `@Telefonica/mistica-web-reviewers` team handle in `CONTRIBUTING.md`.