### PR TITLE
fix(Dialog): restore focus to the trigger element on close

### DIFF
--- a/src/__tests__/dialog-test.tsx
+++ b/src/__tests__/dialog-test.tsx
@@ -307,8 +307,6 @@ const SwitchDialogTrigger = () => {
 };
 
 test('returns focus to the trigger switch when the dialog is closed via keyboard', async () => {
-    jest.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('acceptance-test');
-
     render(
         <ThemeContextProvider theme={makeTheme()}>
             <SwitchDialogTrigger />

--- a/src/__tests__/dialog-test.tsx
+++ b/src/__tests__/dialog-test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {render, waitFor, screen, act} from '@testing-library/react';
-import {ThemeContextProvider, useDialog, Switch} from '..';
+import {ThemeContextProvider, useDialog, Switch, Checkbox, RadioButton, RadioGroup} from '..';
 import {makeTheme} from './test-utils';
 import * as webviewBridge from '@tef-novum/webview-bridge';
 import userEvent from '@testing-library/user-event';
@@ -293,42 +293,64 @@ test('when webview bridge is available nativeConfirm is shown', async () => {
     });
 });
 
-const SwitchDialogTrigger = () => {
+const DialogTrigger = ({renderTrigger}: {renderTrigger: (openDialog: () => void) => React.ReactNode}) => {
     const {dialog} = useDialog();
-    return (
-        <Switch
-            name="notifications"
-            aria-label="notifications"
-            onChange={() => {
-                dialog({message: 'Message'});
-            }}
-        />
-    );
+    return <>{renderTrigger(() => dialog({message: 'Message'}))}</>;
 };
 
-test('returns focus to the trigger switch when the dialog is closed via keyboard', async () => {
-    render(
-        <ThemeContextProvider theme={makeTheme()}>
-            <SwitchDialogTrigger />
-        </ThemeContextProvider>
-    );
+test.each([
+    {
+        type: 'switch',
+        role: 'switch',
+        accessibleName: 'notifications',
+        renderTrigger: (openDialog: () => void) => (
+            <Switch name="notifications" aria-label="notifications" onChange={openDialog} />
+        ),
+    },
+    {
+        type: 'checkbox',
+        role: 'checkbox',
+        accessibleName: 'terms',
+        renderTrigger: (openDialog: () => void) => (
+            <Checkbox name="terms" aria-label="terms" onChange={openDialog} />
+        ),
+    },
+    {
+        type: 'radio button',
+        role: 'radio',
+        accessibleName: 'option',
+        renderTrigger: (openDialog: () => void) => (
+            <RadioGroup name="options" aria-label="options" onChange={openDialog}>
+                <RadioButton value="option" aria-label="option" />
+            </RadioGroup>
+        ),
+    },
+] as const)(
+    'returns focus to the trigger $type when the dialog is closed via keyboard',
+    async ({role, accessibleName, renderTrigger}) => {
+        render(
+            <ThemeContextProvider theme={makeTheme()}>
+                <DialogTrigger renderTrigger={renderTrigger} />
+            </ThemeContextProvider>
+        );
 
-    const switchEl = await screen.findByRole('switch', {name: 'notifications'});
-    switchEl.focus();
-    expect(switchEl).toHaveFocus();
+        const triggerEl = await screen.findByRole(role, {name: accessibleName});
+        triggerEl.focus();
+        expect(triggerEl).toHaveFocus();
 
-    await userEvent.keyboard(' ');
-    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+        await userEvent.keyboard(' ');
+        expect(await screen.findByRole('dialog')).toBeInTheDocument();
 
-    await userEvent.keyboard('{Escape}');
-    await waitFor(() => {
-        expect(screen.queryByRole('dialog', {hidden: true})).not.toBeInTheDocument();
-    });
+        await userEvent.keyboard('{Escape}');
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog', {hidden: true})).not.toBeInTheDocument();
+        });
 
-    await waitFor(() => {
-        expect(switchEl).toHaveFocus();
-    });
-});
+        await waitFor(() => {
+            expect(triggerEl).toHaveFocus();
+        });
+    }
+);
 
 test('dialog close button is accessible', async () => {
     render(

--- a/src/__tests__/dialog-test.tsx
+++ b/src/__tests__/dialog-test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {render, waitFor, screen, act} from '@testing-library/react';
-import {ThemeContextProvider, useDialog} from '..';
+import {ThemeContextProvider, useDialog, Switch} from '..';
 import {makeTheme} from './test-utils';
 import * as webviewBridge from '@tef-novum/webview-bridge';
 import userEvent from '@testing-library/user-event';
@@ -290,6 +290,45 @@ test('when webview bridge is available nativeConfirm is shown', async () => {
             acceptText: 'Yay!',
             cancelText: 'Nope!',
         });
+    });
+});
+
+const SwitchDialogTrigger = () => {
+    const {dialog} = useDialog();
+    return (
+        <Switch
+            name="notifications"
+            aria-label="notifications"
+            onChange={() => {
+                dialog({message: 'Message'});
+            }}
+        />
+    );
+};
+
+test('returns focus to the trigger switch when the dialog is closed via keyboard', async () => {
+    jest.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('acceptance-test');
+
+    render(
+        <ThemeContextProvider theme={makeTheme()}>
+            <SwitchDialogTrigger />
+        </ThemeContextProvider>
+    );
+
+    const switchEl = await screen.findByRole('switch', {name: 'notifications'});
+    switchEl.focus();
+    expect(switchEl).toHaveFocus();
+
+    await userEvent.keyboard(' ');
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+        expect(screen.queryByRole('dialog', {hidden: true})).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+        expect(switchEl).toHaveFocus();
     });
 });
 

--- a/src/focus-trap.tsx
+++ b/src/focus-trap.tsx
@@ -6,7 +6,7 @@ type Props = {
     className?: string;
     disabled?: boolean;
     group?: string;
-    returnFocus?: boolean | FocusOptions | ((returnTo: Element) => boolean | FocusOptions);
+    returnFocus?: React.ComponentProps<typeof ReactFocusLock>['returnFocus'];
 };
 
 const FocusTrap = ({children, disabled, className, group, returnFocus = true}: Props): JSX.Element => (

--- a/src/focus-trap.tsx
+++ b/src/focus-trap.tsx
@@ -6,10 +6,17 @@ type Props = {
     className?: string;
     disabled?: boolean;
     group?: string;
+    returnFocus?: boolean | FocusOptions | ((returnTo: Element) => boolean | FocusOptions);
 };
 
-const FocusTrap = ({children, disabled, className, group}: Props): JSX.Element => (
-    <ReactFocusLock noFocusGuards disabled={disabled} className={className} group={group}>
+const FocusTrap = ({children, disabled, className, group, returnFocus = true}: Props): JSX.Element => (
+    <ReactFocusLock
+        noFocusGuards
+        disabled={disabled}
+        className={className}
+        group={group}
+        returnFocus={returnFocus}
+    >
         {children}
     </ReactFocusLock>
 );

--- a/src/focus-trap.tsx
+++ b/src/focus-trap.tsx
@@ -9,6 +9,7 @@ type Props = {
     returnFocus?: React.ComponentProps<typeof ReactFocusLock>['returnFocus'];
 };
 
+// TODO https://github.com/Telefonica/mistica-web/issues/1589 unify focus-restoration logic with consumers that restore focus manually (e.g. Drawer's useRestoreFocus)
 const FocusTrap = ({children, disabled, className, group, returnFocus = true}: Props): JSX.Element => (
     <ReactFocusLock
         noFocusGuards


### PR DESCRIPTION
## Summary

A `dialog()` opened from a focused trigger did not return keyboard focus to that trigger when the dialog was closed, breaking WCAG SC 2.4.3 (Focus order). The cause: `FocusTrap` never forwarded `returnFocus` to `react-focus-lock`, whose default is `false`, so the focus trap restored no focus on unmount and closing a dialog left focus on `<body>`.

## Changes

- `FocusTrap`: forward a `returnFocus` prop to `react-focus-lock`, defaulting to `true`, so focus is restored to the element that held focus before the trap mounted. `Dialog` inherits this default.

## Behavior

Focus is restored when the trigger was actually focused, for example when a control is reached and activated via the keyboard. Pointer interaction on non-native controls (`Switch`, `Checkbox`, `RadioButton`, which render a `<span>`/`<div>` with a `role`) does not move focus to the control, so the pointer path does not restore focus; this is accepted by design.

## Testing

- Added a regression test in `dialog-test.tsx` for the keyboard path.
- Existing `Drawer`, `Sheet` and navigation burger-menu focus-trap behavior is preserved; their suites pass.

Note: with the new default, a `Sheet` in a non-iframe context now also restores focus to its trigger, which is an accessibility improvement consistent with this fix.

Ref: WEB-2447