### PR TITLE
fix(a11y): restore focus after dialog opened from switch

### DIFF
--- a/src/__tests__/dialog-test.tsx
+++ b/src/__tests__/dialog-test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {render, waitFor, screen, act} from '@testing-library/react';
-import {ThemeContextProvider, useDialog} from '..';
+import {ThemeContextProvider, useDialog, RowList, Row} from '..';
 import {makeTheme} from './test-utils';
 import * as webviewBridge from '@tef-novum/webview-bridge';
 import userEvent from '@testing-library/user-event';
@@ -304,4 +304,139 @@ test('dialog close button is accessible', async () => {
     await userEvent.click(dialogButton);
 
     await screen.findByRole('button', {name: 'custom close label'});
+});
+
+describe('focus return after dialog close', () => {
+    test('returns focus to the trigger button after alert closes', async () => {
+        const TriggerComponent = () => {
+            const {alert} = useDialog();
+            return <button onClick={() => alert({message: 'Alert!', acceptText: 'OK'})}>Trigger</button>;
+        };
+
+        render(
+            <ThemeContextProvider theme={makeTheme()}>
+                <TriggerComponent />
+            </ThemeContextProvider>
+        );
+
+        const triggerButton = screen.getByRole('button', {name: 'Trigger'});
+        triggerButton.focus();
+        expect(triggerButton).toHaveFocus();
+
+        await userEvent.click(triggerButton);
+        await screen.findByRole('dialog');
+
+        const acceptButton = screen.getByRole('button', {name: 'OK'});
+        await userEvent.click(acceptButton);
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog', {hidden: true})).not.toBeInTheDocument();
+        });
+
+        await waitFor(() => {
+            expect(triggerButton).toHaveFocus();
+        });
+    });
+
+    test('returns focus to the switch inside a row after confirm closes', async () => {
+        // Disable animations so dialogs close immediately
+        jest.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('acceptance-test');
+
+        const SwitchInRowComponent = () => {
+            const {confirm} = useDialog();
+            const [checked, setChecked] = React.useState(false);
+
+            const handleChange = (value: boolean) => {
+                setChecked(value);
+                if (value) {
+                    confirm({
+                        message: 'Are you sure?',
+                        acceptText: 'Yes',
+                        cancelText: 'No',
+                        onAccept: () => {},
+                        onCancel: () => setChecked(false),
+                    });
+                }
+            };
+
+            return (
+                <RowList>
+                    <Row
+                        title="Enable feature"
+                        switch={{name: 'feature', value: checked, onChange: handleChange}}
+                    />
+                </RowList>
+            );
+        };
+
+        render(
+            <ThemeContextProvider theme={makeTheme()}>
+                <SwitchInRowComponent />
+            </ThemeContextProvider>
+        );
+
+        const switchEl = screen.getByRole('switch', {name: 'Enable feature'});
+        switchEl.focus();
+        expect(switchEl).toHaveFocus();
+
+        await userEvent.click(switchEl);
+        await screen.findByRole('dialog');
+
+        const cancelButton = screen.getByRole('button', {name: 'No'});
+        await userEvent.click(cancelButton);
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog', {hidden: true})).not.toBeInTheDocument();
+        });
+
+        await waitFor(() => {
+            expect(switchEl).toHaveFocus();
+        });
+    });
+
+    test('returns focus to the switch after alert closes (keyboard activation)', async () => {
+        const SwitchWithAlertComponent = () => {
+            const {alert} = useDialog();
+            const [checked, setChecked] = React.useState(false);
+
+            const handleChange = (value: boolean) => {
+                setChecked(value);
+                if (value) {
+                    alert({message: 'Feature enabled!', acceptText: 'OK'});
+                }
+            };
+
+            return (
+                <RowList>
+                    <Row title="Toggle" switch={{name: 'toggle', value: checked, onChange: handleChange}} />
+                </RowList>
+            );
+        };
+
+        render(
+            <ThemeContextProvider theme={makeTheme()}>
+                <SwitchWithAlertComponent />
+            </ThemeContextProvider>
+        );
+
+        const switchEl = screen.getByRole('switch', {name: 'Toggle'});
+        switchEl.focus();
+        expect(switchEl).toHaveFocus();
+
+        // Activate switch via Space key
+        await userEvent.keyboard(' ');
+
+        await screen.findByRole('dialog');
+
+        const acceptButton = screen.getByRole('button', {name: 'OK'});
+        await userEvent.click(acceptButton);
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog', {hidden: true})).not.toBeInTheDocument();
+        });
+
+        await waitFor(() => {
+            expect(switchEl).toHaveFocus();
+        });
+    });
 });

--- a/src/dialog.tsx
+++ b/src/dialog.tsx
@@ -355,7 +355,7 @@ const ModalDialog = (props: ModalDialogProps): JSX.Element => {
 
     return (
         <Portal className={styles.wrapper}>
-            <FocusTrap>
+            <FocusTrap returnFocusOnDeactivate={false} disabled={isClosing}>
                 {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
                 <div
                     onClick={handleOverlayPress}

--- a/src/focus-trap.tsx
+++ b/src/focus-trap.tsx
@@ -6,10 +6,17 @@ type Props = {
     className?: string;
     disabled?: boolean;
     group?: string;
+    returnFocusOnDeactivate?: boolean;
 };
 
-const FocusTrap = ({children, disabled, className, group}: Props): JSX.Element => (
-    <ReactFocusLock noFocusGuards disabled={disabled} className={className} group={group}>
+const FocusTrap = ({children, disabled, className, group, returnFocusOnDeactivate}: Props): JSX.Element => (
+    <ReactFocusLock
+        noFocusGuards
+        disabled={disabled}
+        className={className}
+        group={group}
+        returnFocus={returnFocusOnDeactivate}
+    >
         {children}
     </ReactFocusLock>
 );

--- a/src/switch-component.tsx
+++ b/src/switch-component.tsx
@@ -149,6 +149,10 @@ const Switch = (props: PropsRender | PropsChildren): JSX.Element => {
             onClick={(e) => {
                 e.stopPropagation();
                 if (!disabled) {
+                    // Ensure the switch has focus before calling onChange, so that
+                    // document.activeElement is the switch when a dialog is opened
+                    // synchronously from the onChange callback (e.g. alert/confirm/dialog).
+                    e.currentTarget.focus();
                     handleChange();
                 }
             }}


### PR DESCRIPTION
## Summary

Fixes #1568 — Dialog does not return focus to the trigger element when opened from a Switch inside Row.

**Root cause:** Two interacting issues:
1. Switch didn't explicitly focus itself on click before calling `onChange`, so `document.activeElement` could be wrong when the Dialog captured the trigger element.
2. FocusTrap remained active during the dialog closing animation, causing `react-focus-lock` to steal focus back after `triggerEl.focus()` fired in the `onDestroy` callback.

**Fix:**
- **`switch-component.tsx`**: Added `e.currentTarget.focus()` before `handleChange()` in the `onClick` handler, ensuring `document.activeElement` is the Switch when `onChange` fires synchronously.
- **`focus-trap.tsx`**: Added `returnFocusOnDeactivate` prop that maps to `react-focus-lock`'s `returnFocus` prop, making focus restoration behavior explicit and configurable.
- **`dialog.tsx`**: Passed `returnFocusOnDeactivate={false}` and `disabled={isClosing}` to FocusTrap. This disables the focus trap when the dialog starts closing (preventing `react-focus-lock` from stealing focus back) and makes it explicit that `DialogRoot.onDestroy` is the single source of truth for focus restoration.

## Test plan

- [x] New test: `returns focus to the trigger button after alert closes` (baseline)
- [x] New test: `returns focus to the switch inside a row after confirm closes` (exact bug scenario, pointer interaction)
- [x] New test: `returns focus to the switch after alert closes (keyboard activation)` (keyboard interaction)
- [x] All existing dialog tests pass (16/16)
- [x] All existing switch tests pass (7/7)
- [x] All existing drawer tests pass (6/6) — Drawer uses `useRestoreFocus`, not affected
- [x] All existing sheet tests pass (19/19) — Sheet uses `focusTriggerElement()`, not affected
- [x] All existing list/row tests pass (19/19)
- [x] All existing navigation bar tests pass (2/2)
- [x] TypeScript: no errors in changed files
- [x] ESLint: no errors in changed files
- [x] Pre-commit hooks (prettier) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)