### PR TITLE
fix(ThemeContextProvider): add unique data-mistica-theme attributes f…

### DIFF
--- a/src/__tests__/theme-context-provider-test.tsx
+++ b/src/__tests__/theme-context-provider-test.tsx
@@ -88,9 +88,10 @@ test('Multiple ThemeContextProvider with as="div" get unique data-mistica-theme 
             >
                 <div data-testid="dark-content" />
             </ThemeContextProvider>
-        </ThemeContextProvider>,
+        </ThemeContextProvider>
     );
-
+    // data-mistica-theme is a non-semantic attribute with no Testing Library query
+    // eslint-disable-next-line testing-library/no-node-access
     const themedDivs = container.querySelectorAll('[data-mistica-theme]');
     expect(themedDivs).toHaveLength(2);
 
@@ -118,9 +119,10 @@ test('ThemeContextProvider with as="div" and withoutStyles does not add data-mis
             >
                 <div data-testid="content" />
             </ThemeContextProvider>
-        </ThemeContextProvider>,
+        </ThemeContextProvider>
     );
-
+    // data-mistica-theme is a non-semantic attribute with no Testing Library query
+    // eslint-disable-next-line testing-library/no-node-access
     const themedDivs = container.querySelectorAll('[data-mistica-theme]');
     expect(themedDivs).toHaveLength(0);
 });

--- a/src/__tests__/theme-context-provider-test.tsx
+++ b/src/__tests__/theme-context-provider-test.tsx
@@ -58,3 +58,69 @@ test('ThemeContextProvider override some texts', () => {
     expect(screen.getByLabelText('Any expiration label')).toBeInTheDocument();
     expect(screen.getByLabelText('CVV')).toBeInTheDocument();
 });
+
+test('Multiple ThemeContextProvider with as="div" get unique data-mistica-theme attributes', () => {
+    const {container} = render(
+        <ThemeContextProvider
+            theme={{
+                skin: getMovistarSkin(),
+                i18n: {locale: 'es-ES', phoneNumberFormattingRegionCode: 'ES'},
+            }}
+        >
+            <ThemeContextProvider
+                as="div"
+                theme={{
+                    skin: getMovistarSkin(),
+                    colorScheme: 'light',
+                    i18n: {locale: 'es-ES', phoneNumberFormattingRegionCode: 'ES'},
+                }}
+            >
+                <div data-testid="light-content" />
+            </ThemeContextProvider>
+
+            <ThemeContextProvider
+                as="div"
+                theme={{
+                    skin: getMovistarSkin(),
+                    colorScheme: 'dark',
+                    i18n: {locale: 'es-ES', phoneNumberFormattingRegionCode: 'ES'},
+                }}
+            >
+                <div data-testid="dark-content" />
+            </ThemeContextProvider>
+        </ThemeContextProvider>,
+    );
+
+    const themedDivs = container.querySelectorAll('[data-mistica-theme]');
+    expect(themedDivs).toHaveLength(2);
+
+    const ids = Array.from(themedDivs).map((el) => el.getAttribute('data-mistica-theme'));
+    // Each instance should have a unique identifier
+    expect(ids[0]).not.toBe(ids[1]);
+});
+
+test('ThemeContextProvider with as="div" and withoutStyles does not add data-mistica-theme', () => {
+    const {container} = render(
+        <ThemeContextProvider
+            theme={{
+                skin: getMovistarSkin(),
+                i18n: {locale: 'es-ES', phoneNumberFormattingRegionCode: 'ES'},
+            }}
+        >
+            <ThemeContextProvider
+                as="div"
+                withoutStyles
+                theme={{
+                    skin: getMovistarSkin(),
+                    colorScheme: 'dark',
+                    i18n: {locale: 'es-ES', phoneNumberFormattingRegionCode: 'ES'},
+                }}
+            >
+                <div data-testid="content" />
+            </ThemeContextProvider>
+        </ThemeContextProvider>,
+    );
+
+    const themedDivs = container.querySelectorAll('[data-mistica-theme]');
+    expect(themedDivs).toHaveLength(0);
+});

--- a/src/theme-context-provider.tsx
+++ b/src/theme-context-provider.tsx
@@ -140,7 +140,7 @@ const makeRawColors = (colors: Colors): Colors =>
     ) as Colors;
 
 const ThemeContextProvider = ({theme, children, as, withoutStyles = false}: Props): JSX.Element => {
-    const instanceId = React.useId();
+    const themeScopeId = React.useId();
     const isOsDarkModeEnabled = useIsOsDarkModeEnabled();
 
     const colorScheme = theme.colorScheme ?? 'auto';
@@ -334,7 +334,7 @@ const ThemeContextProvider = ({theme, children, as, withoutStyles = false}: Prop
                                                     {as ? (
                                                         <>
                                                             {renderStyles(
-                                                                `[data-mistica-theme="${instanceId}"]`
+                                                                `[data-mistica-theme="${themeScopeId}"]`
                                                             )}
                                                             {React.createElement(
                                                                 as,
@@ -342,12 +342,9 @@ const ThemeContextProvider = ({theme, children, as, withoutStyles = false}: Prop
                                                                     style: {
                                                                         isolation: 'isolate',
                                                                     },
-                                                                    className: withoutStyles
-                                                                        ? undefined
-                                                                        : styles.themeVars,
                                                                     'data-mistica-theme': withoutStyles
                                                                         ? undefined
-                                                                        : instanceId,
+                                                                        : themeScopeId,
                                                                 },
                                                                 children
                                                             )}

--- a/src/theme-context-provider.tsx
+++ b/src/theme-context-provider.tsx
@@ -140,6 +140,7 @@ const makeRawColors = (colors: Colors): Colors =>
     ) as Colors;
 
 const ThemeContextProvider = ({theme, children, as, withoutStyles = false}: Props): JSX.Element => {
+    const instanceId = React.useId();
     const isOsDarkModeEnabled = useIsOsDarkModeEnabled();
 
     const colorScheme = theme.colorScheme ?? 'auto';
@@ -332,7 +333,9 @@ const ThemeContextProvider = ({theme, children, as, withoutStyles = false}: Prop
                                                 <SnackbarRoot>
                                                     {as ? (
                                                         <>
-                                                            {renderStyles(`.${styles.themeVars}`)}
+                                                            {renderStyles(
+                                                                `[data-mistica-theme="${instanceId}"]`
+                                                            )}
                                                             {React.createElement(
                                                                 as,
                                                                 {
@@ -342,6 +345,9 @@ const ThemeContextProvider = ({theme, children, as, withoutStyles = false}: Prop
                                                                     className: withoutStyles
                                                                         ? undefined
                                                                         : styles.themeVars,
+                                                                    'data-mistica-theme': withoutStyles
+                                                                        ? undefined
+                                                                        : instanceId,
                                                                 },
                                                                 children
                                                             )}

--- a/src/theme-context-provider.tsx
+++ b/src/theme-context-provider.tsx
@@ -26,7 +26,6 @@ import {PACKAGE_VERSION} from './package-version';
 import {SnackbarRoot} from './snackbar-context';
 import {mapToWeight} from './text';
 import * as mq from './media-queries.css';
-import * as styles from './theme-context.css';
 import {localeToLanguage} from './utils/locale';
 
 import type {Colors, TextPresetsConfig} from './skins/types';


### PR DESCRIPTION
…or multiple ThemeContextProvider instances Ref: VIVO-5902

You can reproduce the bug [here](https://mistica-web.vercel.app/playroom#?code=N4Igxg9gJgpiBcIA8BlALgQzAawAQGcAHLGAXmAEYA2AXwD4AdAO11yQBUYAPNAZlwC2MKAEsArgLoAhMQHNcAJxiEFEeLnYALGEIDCEJmm5oACqoBuI2Aty6UKXGAA2GfPkcQnTkfhEGkAPScPLyMLGwAkkzeTDAExGBklLRhrKzAAQBUuAAyIrKaaLgiTPiYTIm4mQE0zGlsWjow%2BobGZhCW1nX1uK6kDCCi5gPd9WjaQuTA%2BNgl6rIwaACyHT6YCiizTAAUAJQANB5OEBtgEzDqAOTeBWiXhyIUABxM6sDHYBhOF7iXMEwAWgA4lJ7rhCJoDDAAHISABGMAUADETgIMGg0CVZAAlGCyPxMfSwK4gy40cmjXCpHpIIYENAAT2%2BUzhWGwslUYiYUH0xwU6hmJQAahgFPgAHSQPkS1k4DkQLlQQ5wk7WK4AJkIXAInisuA5MH%2BZPolPqqEwOHiJHITxN4R6aQ4xnVgmE4kkOQiQIAEuxcNsDf9cCqFNZdoFgmh1dSHawkBFIEwVnCRN8ACIwSyJXGyMQuGxSk7kQVMEViyWeE4SxNoVROACCYEx5nRwhouACMdjTp4FEUeLzoroWh8BEheaguE0GHMcQwuS9vuDbPliojxgoXbNAXQbK3bACQy7EfOLSMPHanURXYy2TTorwJTKGAqcUAKAT97mI4S9ABmRhsG5CkOT4xHwGB3HGOI4TkKoakpDhTwMc9TAsKxEVNXp8H6QYRGGEBMKgyZgGmLZ5kWFZLGfDYtj2EDK1Oc4rigB8wUeF43g%2BL4fj%2BQFSUOCEoVhAQEWRVF0UxJgcTxAkiR40lyVqe0qUw2k8PpJkkmAWV2U5bleROAUtjLasGJlFc9KVYNVURDUtR1bxJxOF8FmNfc413S0iGtYBbXcx1IxdIRRAkOg03rbEAGl-WcqToJshRwyCZ1-LjBMDGTVMYAzLMYBzQcCwY4tjNFUzpQrQw60bZtWygdtO0ws1Iz7JRc3zYdNFHfBxycSdp1nXpcHCqLlzlSz117fzAk87B90CI8EKCJDWgvNDrGpQIohiGANua-s2tFI4i1I4VSorcqUJQGBExYhQGTtepAETCXAIl-XApAAeXYb1rK4CCxwgAB3XBbrwHTV25Q4oODWDR0TX8RAUYL4EpaHQeKUpykSS53DKTTcEweQOkRBR0Mg7RcCAoooWDa6MDAuIoIZMdRUZin8AwIRbHsRwXDcAgYG%2BJsTnFboJrQTdmGmi1ZpAfYQCIiCEAAbRAIU8IgAB9aEYEBkAAF0aCAA)

Before: 

<img width="800" height="252" alt="Screenshot 2026-06-23 at 17 07 26" src="https://github.com/user-attachments/assets/24267350-bdab-4f8d-a750-5143585ea25b" />


Now: 

<img width="710" height="245" alt="Screenshot 2026-06-23 at 17 09 33" src="https://github.com/user-attachments/assets/81efb9a8-a90b-4b10-8e3c-b2b8d4ab4de8" />
