### PR TITLE
chore(CODEOWNERS): set mistica-web-reviewers as default code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Telefonica/mistica-web-reviewers


### PR DESCRIPTION
## What

Adds a `.github/CODEOWNERS` file assigning `@Telefonica/mistica-web-reviewers` as the default code owner for the entire repository.

## Why

There was no CODEOWNERS file (the working entry was incomplete: `* @telefonica/`). Setting the `mistica-web-reviewers` team as default owner ensures the team is automatically requested for review on every pull request.

## Notes

- For these assignments to take effect, the `mistica-web-reviewers` team must have **write access** to the repository; otherwise GitHub silently ignores the entry.