### PR TITLE
fix(SearchField): prevent layout shift in nav bar when clear button appears

### DIFF
--- a/src/search-field.tsx
+++ b/src/search-field.tsx
@@ -106,13 +106,18 @@ const SearchField = React.forwardRef<any, SearchFieldProps>(
                 ref={combineRefs(inputRef, ref)}
                 startIcon={withStartIcon ? <IconSearchRegular size={iconSize.small} /> : undefined}
                 endIcon={
-                    controlledValue ? (
+                    // Always render to reserve space and prevent layout shift in nav bars;
+                    // hide visually and from assistive tech when the field is empty.
+                    <span
+                        style={controlledValue ? undefined : {visibility: 'hidden'}}
+                        aria-hidden={!controlledValue ? true : undefined}
+                    >
                         <FieldEndIcon
                             Icon={IconCloseRegular}
                             aria-label={texts.formSearchClear || t(tokens.formSearchClear)}
                             onPress={clearInput}
                         />
-                    ) : undefined
+                    </span>
                 }
                 {...rest}
                 {...fieldProps}


### PR DESCRIPTION
## Summary

Fixes #1635

When a `SearchField` is placed in the right slot of a `MainNavigationBar`, typing into it caused a layout shift: the "×" clear button mounted into the DOM, adding ~19 px of icon container width and shifting adjacent items (e.g. the avatar/action button).

**Root cause:** The clear `FieldEndIcon` was conditionally rendered (`endIcon={controlledValue ? <FieldEndIcon …/> : undefined}`). Mounting/unmounting it changed the field's internal flex layout and caused a reflow visible in the parent nav bar.

**Fix:** The icon is now always rendered. When the field is empty the wrapper `<span>` carries `visibility: hidden` + `aria-hidden="true"`, reserving the space without showing or exposing the button. This keeps the field width constant regardless of whether the user has typed anything.

## Test plan

- [ ] Open the [Playroom reproduction](https://mistica-web.vercel.app/playroom#?code=N4Igxg9gJgpiBcIA8BZAhgSwHYDk0DcMBzNAFwwiwCE0AnAHSwAInbiALUgXmEZaQCSWADbYYTAM4AHNGBg8AjADYAvkzSiiWAaRgBbCV3rgYWXQxBMYADxlYoPAAwqAfHxYfP-AMow6YdgAxDBhhKCYAMwBXYWEAdQwoUnYmLDQ9eWMJP1oA4yZhNAAjUKMQX392fIB6Nyx3Ly8kPEISckoaWgBBMHbmSgAFWhgJQ2AACgBKJi4XJmAVNToMNABaQpLhMoBRM1o6YzrG-i78MgPmY5YJDAAveWAMCQAREYBrUggpAHlaKmIiDBaEwAPxMADMACYmPAmJCACwqBrHbAYcgaQzGFAAGWMyMaElyZU4pCkEng1WqUgwYAkUT0ADopOwIJ8JNUFJDHI4OVzHHjLo1avirh5Hi93p8fn8AUCmAAyeVMADku1I%2B1oyqRgtFSGqLWIZAo1DoPT6R2OeqEoiwMBc2uFWBAABoQMl9CMEABtEAoCCECSkOgAfRwMAA7iAALqu8OJZISb0KAAcUKjKiAA) — the nav bar right slot no longer shifts when typing starts.
- [ ] Verify the "×" button appears on type and clears the field correctly.
- [ ] Verify the "×" button is not visible or keyboard-focusable when the field is empty.
- [ ] All existing `SearchField` unit tests pass (`npx jest src/__tests__/search-field-test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)