### PR TITLE
feat(tokens): enable responsiveLayoutMargin token in ResponsiveLayout

### DIFF
--- a/src/community/skins/cyber-skin.tsx
+++ b/src/community/skins/cyber-skin.tsx
@@ -1113,6 +1113,7 @@ export const getCyberSkin = (): Skin => {
                     desktop: 40,
                 },
             },
+            responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
         },
     };
     return skin;

--- a/src/responsive-layout.css.ts
+++ b/src/responsive-layout.css.ts
@@ -11,10 +11,10 @@ export const EXTRA_LARGE_DESKTOP_MAX_WIDTH = 1704;
 
 const marginValue = {
     extraLargeDesktop: `calc((100vw - ${EXTRA_LARGE_DESKTOP_MAX_WIDTH}px) / 2)`,
-    largeDesktop: `${LARGE_DESKTOP_SIDE_MARGIN}px`,
-    desktop: `${SMALL_DESKTOP_SIDE_MARGIN}px`,
-    tablet: `${TABLET_SIDE_MARGIN}px`,
-    mobile: `${MOBILE_SIDE_MARGIN}px`,
+    largeDesktop: skinVars.spacing.responsiveLayoutMargin.largeDesktop,
+    desktop: skinVars.spacing.responsiveLayoutMargin.desktop,
+    tablet: skinVars.spacing.responsiveLayoutMargin.tablet,
+    mobile: skinVars.spacing.responsiveLayoutMargin.mobile,
 };
 
 const currentMargin = createVar();

--- a/src/skins/blau.tsx
+++ b/src/skins/blau.tsx
@@ -718,6 +718,7 @@ export const getBlauSkin: GetKnownSkin = () => {
                 left: {mobile: 16, desktop: 40},
                 right: {mobile: 16, desktop: 40},
             },
+            responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
         },
     };
     return skin;

--- a/src/skins/defaults.tsx
+++ b/src/skins/defaults.tsx
@@ -101,4 +101,5 @@ export const defaultSpacing: SpacingConfig = {
         left: {mobile: 16, desktop: 24},
         right: {mobile: 16, desktop: 24},
     },
+    responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
 };

--- a/src/skins/esimflag.tsx
+++ b/src/skins/esimflag.tsx
@@ -722,6 +722,7 @@ export const getEsimflagSkin: GetKnownSkin = () => {
                 left: {mobile: 16, desktop: 40},
                 right: {mobile: 16, desktop: 40},
             },
+            responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
         },
     };
     return skin;

--- a/src/skins/movistar-new.tsx
+++ b/src/skins/movistar-new.tsx
@@ -729,6 +729,7 @@ export const getMovistarNewSkin: GetKnownSkin = () => {
                 left: {mobile: 16, desktop: 24},
                 right: {mobile: 16, desktop: 24},
             },
+            responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
         },
     };
     return skin;

--- a/src/skins/movistar.tsx
+++ b/src/skins/movistar.tsx
@@ -734,6 +734,7 @@ export const getMovistarSkin: GetKnownSkin = () => {
                 left: {mobile: 16, desktop: 40},
                 right: {mobile: 16, desktop: 40},
             },
+            responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
         },
     };
     return skin;

--- a/src/skins/o2-new.tsx
+++ b/src/skins/o2-new.tsx
@@ -725,6 +725,7 @@ export const getO2NewSkin: GetKnownSkin = () => {
                 left: {mobile: 16, desktop: 40},
                 right: {mobile: 16, desktop: 40},
             },
+            responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
         },
     };
     return skin;

--- a/src/skins/o2.tsx
+++ b/src/skins/o2.tsx
@@ -721,6 +721,7 @@ export const getO2Skin: GetKnownSkin = () => {
                 left: {mobile: 16, desktop: 40},
                 right: {mobile: 16, desktop: 40},
             },
+            responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
         },
     };
     return skin;

--- a/src/skins/skin-contract.css.ts
+++ b/src/skins/skin-contract.css.ts
@@ -305,7 +305,7 @@ const borderRadii: BorderRadiiConfig = {
     tag: '',
 };
 
-type ToThemeTokens<T> = T extends {mobile: number; desktop: number}
+type ToThemeTokens<T> = keyof T extends 'mobile' | 'desktop'
     ? string
     : T extends object
       ? {[K in keyof T]: ToThemeTokens<T[K]>}
@@ -364,6 +364,7 @@ const spacing: ToThemeTokens<SpacingConfig> = {
     heroPadding: {top: '', bottom: ''},
     headerPadding: {top: '', bottom: ''},
     drawerPadding: {top: '', bottom: '', left: '', right: ''},
+    responsiveLayoutMargin: {mobile: '', tablet: '', desktop: '', largeDesktop: ''},
 };
 
 export const vars = createThemeContract({

--- a/src/skins/telefonica.tsx
+++ b/src/skins/telefonica.tsx
@@ -762,6 +762,7 @@ export const getTelefonicaSkin: GetKnownSkin = () => {
                 left: {mobile: 16, desktop: 40},
                 right: {mobile: 16, desktop: 40},
             },
+            responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
         },
     };
     return skin;

--- a/src/skins/tu.tsx
+++ b/src/skins/tu.tsx
@@ -735,6 +735,7 @@ export const getTuSkin: GetKnownSkin = () => {
                 left: {mobile: 16, desktop: 40},
                 right: {mobile: 16, desktop: 40},
             },
+            responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
         },
     };
     return skin;

--- a/src/skins/types/index.tsx
+++ b/src/skins/types/index.tsx
@@ -36,6 +36,13 @@ type PaddingXValues = {
 
 type PaddingValues = PaddingYValues & PaddingXValues;
 
+export type ResponsiveMarginValues = {
+    mobile: number;
+    tablet: number;
+    desktop: number;
+    largeDesktop: number;
+};
+
 type TextWeightTokenConfig<PossibleFontWeights = FontWeight> = {
     weight: PossibleFontWeights;
     size?: never;
@@ -125,6 +132,7 @@ export type SpacingConfig = {
     heroPadding: PaddingYValues;
     headerPadding: PaddingYValues;
     drawerPadding: PaddingValues;
+    responsiveLayoutMargin: ResponsiveMarginValues;
 };
 
 export type ThemeVariantsConfig = {

--- a/src/skins/vivo-new.tsx
+++ b/src/skins/vivo-new.tsx
@@ -739,6 +739,7 @@ export const getVivoNewSkin: GetKnownSkin = () => {
                 left: {mobile: 16, desktop: 40},
                 right: {mobile: 16, desktop: 40},
             },
+            responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
         },
     };
     return skin;

--- a/src/skins/vivo.tsx
+++ b/src/skins/vivo.tsx
@@ -714,6 +714,7 @@ export const getVivoSkin: GetKnownSkin = () => {
                 left: {mobile: 16, desktop: 40},
                 right: {mobile: 16, desktop: 40},
             },
+            responsiveLayoutMargin: {mobile: 16, tablet: 32, desktop: 48, largeDesktop: 64},
         },
     };
     return skin;

--- a/src/theme-context-provider.tsx
+++ b/src/theme-context-provider.tsx
@@ -245,6 +245,17 @@ const ThemeContextProvider = ({theme, children, as, withoutStyles = false}: Prop
 
     const spacingDesktopVars = React.useMemo(() => {
         const tokenValues = Object.entries(contextTheme.spacing).map(([token, values]) => {
+            if ('largeDesktop' in values) {
+                const m = values as {mobile: number; tablet: number; desktop: number; largeDesktop: number};
+                return {
+                    [token]: {
+                        mobile: `${m.mobile}px`,
+                        tablet: `${m.tablet}px`,
+                        desktop: `${m.desktop}px`,
+                        largeDesktop: `${m.largeDesktop}px`,
+                    },
+                };
+            }
             return {
                 [token]: {
                     ...('top' in values && {top: `${values.top.desktop}px`}),
@@ -259,6 +270,17 @@ const ThemeContextProvider = ({theme, children, as, withoutStyles = false}: Prop
 
     const spacingMobileVars = React.useMemo(() => {
         const tokenValues = Object.entries(contextTheme.spacing).map(([token, values]) => {
+            if ('largeDesktop' in values) {
+                const m = values as {mobile: number; tablet: number; desktop: number; largeDesktop: number};
+                return {
+                    [token]: {
+                        mobile: `${m.mobile}px`,
+                        tablet: `${m.tablet}px`,
+                        desktop: `${m.desktop}px`,
+                        largeDesktop: `${m.largeDesktop}px`,
+                    },
+                };
+            }
             return {
                 [token]: {
                     ...('top' in values && {top: `${values.top.mobile}px`}),


### PR DESCRIPTION
## Summary

- Adds the `responsiveLayoutMargin` design token (from [mistica-design#2662](https://github.com/Telefonica/mistica-design/pull/2662)) to the skin type system and all known skins
- The `ResponsiveLayout` component now reads side-margin values from the skin token instead of hardcoded constants, enabling per-brand margins
- The `extraLargeDesktop` breakpoint continues to use the existing `calc((100vw - 1704px) / 2)` centring formula (the token's `"auto"` semantic)

## Changes

**Type system (`SpacingConfig`):**
- Added `ResponsiveMarginValues` type `{mobile, tablet, desktop, largeDesktop}: number`
- Added `responsiveLayoutMargin: ResponsiveMarginValues` to `SpacingConfig`
- Fixed `ToThemeTokens` conditional to use `keyof T extends 'mobile' | 'desktop'` so per-breakpoint token objects expand to individual CSS vars instead of collapsing to a single var

**Skin contract:**
- `spacing.responsiveLayoutMargin` contract entry with four CSS vars (one per breakpoint)
- All skins seeded with 16 / 32 / 48 / 64 per the design spec

**Theme infrastructure:**
- `theme-context-provider` detects the new token shape (via `'largeDesktop' in values`) and sets all four CSS vars directly; no media-query override is needed since breakpoint selection is handled in the CSS file

**ResponsiveLayout CSS:**
- `marginValue.{mobile,tablet,desktop,largeDesktop}` now reference the skin CSS vars; the hardcoded constants remain exported for `sheet-common.tsx` backward compatibility

## Test plan

- [ ] TypeScript passes (`tsc --noEmit`)
- [ ] Existing unit tests pass (pre-existing failures in `snackbar-test` / `cover-card-test` are unrelated)
- [ ] Visually verify that ResponsiveLayout margins match the design spec at each breakpoint for a few skins

Closes #1611

🤖 Generated with [Claude Code](https://claude.com/claude-code)