### PR TITLE
chore(release): fix publish major workflows

### DIFF
--- a/.github/workflows/deprecate-npm-version.yml
+++ b/.github/workflows/deprecate-npm-version.yml
@@ -1,0 +1,29 @@
+name: Deprecate npm version
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'Package version to deprecate (e.g., 16.72.0)'
+                required: true
+                type: string
+            message:
+                description: 'Deprecation message'
+                required: false
+                type: string
+                default: 'This version has been deprecated'
+
+jobs:
+    deprecate:
+        runs-on: ubuntu-latest
+        environment: production
+        steps:
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '18'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Deprecate version
+              run: npm deprecate -f @telefonica/mistica@${{ github.event.inputs.version }} "${{ github.event.inputs.message }}"
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deprecate-npm-version.yml
+++ b/.github/workflows/deprecate-npm-version.yml
@@ -24,6 +24,14 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Deprecate version
-              run: npm deprecate -f @telefonica/mistica@${{ github.event.inputs.version }} "${{ github.event.inputs.message }}"
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+                  VERSION_INPUT: ${{ github.event.inputs.version }}
+                  MESSAGE_INPUT: ${{ github.event.inputs.message }}
+              run: |
+                  # Strict validation: semver format (x.y.z with optional -alpha.1, -beta.2, etc.)
+                  if ! echo "$VERSION_INPUT" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?$'; then
+                    echo "Error: Invalid version format. Must be semver (e.g., 1.2.3 or 1.2.3-alpha.1)"
+                    exit 1
+                  fi
+                  npm deprecate "@telefonica/mistica@$VERSION_INPUT" "$MESSAGE_INPUT"

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
         "*.{js,css,md,yml,yaml,ts,tsx,d.ts,json,html}": "prettier --write"
     },
     "release": {
+        "preset": "angular",
         "plugins": [
             "@semantic-release/commit-analyzer",
             "@semantic-release/release-notes-generator",


### PR DESCRIPTION
# Problem 
The CI validator (GitHub Action) was accepting `!` as valid conventional commits syntax, but semantic-release wasn't configured to use the same spec.

So:

✅ CI said: "Your PR title follows conventional commits with !—approved"
❌ semantic-release said: "I don't recognize !—treating this as minor"
Result: commits merged with ! but didn't trigger major bumps
The mismatch between validation and actual processing is what broke things.

# Solution
so now I gotta:
1. Deprecate 16.72.0
2. Add "preset": "angular" to the release config
3. Rewrite master (remove 16.72.0 release commit, but I'm gonna keep the tag for reference)
4. re-run release -> it now should be able to recognize `!` and create 17.0.0

this branch is supposed to fix this

 With this PR everything is aligned—and future PRs with `!` will correctly release as major versions.