### PR TITLE
chore(Workflows): improve fork PR preview deployment comments

### DIFF
--- a/.github/actions/deploy-vercel-preview/action.yml
+++ b/.github/actions/deploy-vercel-preview/action.yml
@@ -23,6 +23,11 @@ inputs:
         required: false
         default: ${{ github.workspace }}
 
+outputs:
+    preview-url:
+        description: The Vercel preview deployment URL
+        value: ${{ steps.vercel-deploy.outputs.preview-url }}
+
 runs:
     using: composite
     steps:

--- a/.github/workflows/deploy-fork-pr-preview.yml
+++ b/.github/workflows/deploy-fork-pr-preview.yml
@@ -66,7 +66,6 @@ jobs:
                   vercel-project-id: ${{ secrets.MISTICA_WEB_VERCEL_PROJECT_ID }}
                   vercel-project-name: mistica-web
                   working-directory: ${{ github.workspace }}
-                  github-comment: 'false'
 
             - name: Comment deploy result on PR
               if: always() && steps.pr.outputs.pr_number != ''

--- a/.github/workflows/deploy-fork-pr-preview.yml
+++ b/.github/workflows/deploy-fork-pr-preview.yml
@@ -1,4 +1,5 @@
 name: deploy-fork-pr-preview
+run-name: Deploy fork PR number ${{ inputs.prNumber }}
 on:
     workflow_dispatch:
         inputs:
@@ -55,7 +56,9 @@ jobs:
                   ref: ${{ steps.pr.outputs.merge_ref }}
                   persist-credentials: false
 
-            - uses: ./.github/actions/deploy-vercel-preview
+            - name: Deploy preview
+              id: deploy
+              uses: ./.github/actions/deploy-vercel-preview
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -63,3 +66,28 @@ jobs:
                   vercel-project-id: ${{ secrets.MISTICA_WEB_VERCEL_PROJECT_ID }}
                   vercel-project-name: mistica-web
                   working-directory: ${{ github.workspace }}
+                  github-comment: 'false'
+
+            - name: Comment deploy result on PR
+              if: always() && steps.pr.outputs.pr_number != ''
+              uses: actions/github-script@v7
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const prNumber = Number('${{ steps.pr.outputs.pr_number }}');
+                      const { owner, repo } = context.repo;
+                      const marker = '<!-- vercel-preview-url -->';
+
+                      const succeeded = '${{ steps.deploy.outcome }}' === 'success';
+                      const body = succeeded
+                        ? `${marker}\n### Vercel Preview\n\n| Name | Link |\n| --- | --- |\n| Preview | ${{ steps.deploy.outputs.preview-url }} |`
+                        : `${marker}\n### Vercel Preview\n\n> [!CAUTION]\n> Deployment failed. [Check the workflow run](https://github.com/${owner}/${repo}/actions/runs/${{ github.run_id }}) for details.`;
+
+                      const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber });
+                      const existing = comments.find(c => c.body && c.body.includes(marker));
+
+                      if (existing) {
+                        await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                      } else {
+                        await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+                      }

--- a/.github/workflows/deploy-pull-requests.yml
+++ b/.github/workflows/deploy-pull-requests.yml
@@ -10,6 +10,35 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    fork-deploy-reminder:
+        runs-on: ubuntu-latest
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        steps:
+            - name: Comment fork deploy instructions
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const { owner, repo } = context.repo;
+                      const prNumber = context.issue.number;
+                      const marker = '<!-- fork-deploy-reminder -->';
+                      const body = [
+                        marker,
+                        '### Preview deployment',
+                        '',
+                        'This PR comes from a fork and cannot be deployed automatically.',
+                        'To trigger a preview deployment, a maintainer must add the `safe-to-deploy` label.',
+                        '',
+                        '> [!NOTE]',
+                        '> If the label is already present, remove it and add it again to re-trigger the deployment.',
+                      ].join('\n');
+
+                      const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber });
+                      const existing = comments.find(c => c.body && c.body.includes(marker));
+
+                      if (!existing) {
+                        await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+                      }
+
     deploy:
         runs-on: ubuntu-latest
         # Security: only deploy PRs from same repo, not from forks

--- a/.github/workflows/label-trigger-deploy.yml
+++ b/.github/workflows/label-trigger-deploy.yml
@@ -40,7 +40,7 @@ jobs:
                         return;
                       }
 
-                      await github.rest.actions.createWorkflowDispatch({
+                      const { data: dispatch } = await github.rest.actions.createWorkflowDispatch({
                         owner,
                         repo,
                         workflow_id: 'deploy-fork-pr-preview.yml',
@@ -51,5 +51,14 @@ jobs:
                       core.info(`Dispatched deploy-fork-pr-preview for PR #${prNumber}`);
 
                       // post an audit comment on the PR
-                      const commentBody = `Label '${TARGET_LABEL}' added — dispatching fork preview workflow. Awaiting environment approval to expose deploy secrets.`;
+                      const runUrl = dispatch.html_url ?? `https://github.com/${owner}/${repo}/actions`;
+                      const commentBody = [
+                        '### 🚀 Fork preview deploy triggered',
+                        '',
+                        `The \`${TARGET_LABEL}\` label was added and the fork preview workflow has been dispatched.`,
+                        '',
+                        '> [!IMPORTANT]',
+                        '> A reviewer must **approve the workflow run** before it can access deploy secrets.',
+                        `> [Open the run and click **Review deployments** to approve it.](${runUrl})`,
+                      ].join('\n');
                       await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body: commentBody });


### PR DESCRIPTION
## Summary

- `amondnet/vercel-action` cannot post a PR comment when triggered by `workflow_dispatch` (it reads `context.issue.number`, which is `0` outside `pull_request` events). The fork preview workflow now disables the built-in comment and posts the result itself, using the `preview-url` output exposed by the composite action.
- A unified comment step posts either the preview URL or a failure notice (with a link to the run), and creates/updates using an HTML marker to avoid duplicates on retries.
- `deploy-pull-requests.yml` gains a `fork-deploy-reminder` job that comments once on fork PRs explaining how to trigger a deployment via the `safe-to-deploy` label.

## Test plan

- [ ] Open a fork PR and verify the reminder comment is posted once (and not duplicated on subsequent pushes).
- [ ] Add `safe-to-deploy` label on a fork PR, approve the workflow run, and verify the preview URL comment appears on the PR.
- [ ] Re-trigger the fork deploy and verify the existing comment is updated rather than a new one created.
- [ ] Simulate a deploy failure and verify the failure notice comment appears/updates on the PR.
- [ ] Open a non-fork PR and verify the existing behaviour is unchanged (no reminder comment, Vercel action posts its own comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)