### PR TITLE
chore(Workflows): pin commit SHA to prevent TOCTOU attack on fork deployments

### DIFF
--- a/.github/workflows/deploy-fork-pr-preview.yml
+++ b/.github/workflows/deploy-fork-pr-preview.yml
@@ -6,6 +6,9 @@ on:
             prNumber:
                 description: 'Pull request number to deploy preview for'
                 required: true
+            commitSha:
+                description: 'Exact commit SHA at the time the safe-to-deploy label was added'
+                required: true
 
 permissions:
     contents: read
@@ -30,6 +33,12 @@ jobs:
                         return;
                       }
 
+                      const commitSha = '${{ github.event.inputs.commitSha }}';
+                      if (!/^[0-9a-f]{40}$/i.test(commitSha)) {
+                        core.setFailed('Invalid commitSha input: must be a 40-character hex SHA');
+                        return;
+                      }
+
                       const {owner, repo} = context.repo;
                       const {data: pr} = await github.rest.pulls.get({owner, repo, pull_number: prNumber});
 
@@ -43,17 +52,22 @@ jobs:
                         return;
                       }
 
+                      if (pr.head.sha !== commitSha) {
+                        core.setFailed(`Commit SHA mismatch: the PR head is now ${pr.head.sha} but this workflow was triggered for ${commitSha}. The fork may have been updated after the label was added.`);
+                        return;
+                      }
+
                       const labels = (pr.labels || []).map((label) => label.name);
                       if (!labels.includes(REQUIRED_LABEL)) {
                         core.setFailed(`PR #${prNumber} is missing required label: ${REQUIRED_LABEL}`);
                         return;
                       }
 
-                      core.setOutput('merge_ref', `refs/pull/${prNumber}/merge`);
+                      core.setOutput('commit_sha', commitSha);
                       core.setOutput('pr_number', String(prNumber));
             - uses: actions/checkout@v6
               with:
-                  ref: ${{ steps.pr.outputs.merge_ref }}
+                  ref: ${{ steps.pr.outputs.commit_sha }}
                   persist-credentials: false
 
             - name: Deploy preview

--- a/.github/workflows/label-trigger-deploy.yml
+++ b/.github/workflows/label-trigger-deploy.yml
@@ -45,7 +45,7 @@ jobs:
                         repo,
                         workflow_id: 'deploy-fork-pr-preview.yml',
                         ref: 'master',
-                        inputs: { prNumber: String(prNumber) },
+                        inputs: { prNumber: String(prNumber), commitSha: pr.head.sha },
                         return_run_details: true,
                       });
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ automatically. The process requires a maintainer to explicitly approve each step
 1. A maintainer approves the CI run on the PR so the standard checks execute against the fork's code.
 2. A maintainer reviews the PR and adds the `safe-to-deploy` label. This captures the exact commit SHA at that
    moment and triggers the deployment workflow.
-3. The triggered workflow post a link to the workflow run, which a manitainer has to approve. This approval
+3. The triggered workflow post a link to the workflow run, which a maintainer has to approve. This approval
    gate is required before any secrets are exposed.
 4. Once approved, the preview is deployed against the pinned commit SHA. The deployment URL is printed in the
    workflow run logs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,13 +60,11 @@ Always add the `@Telefonica/mistica-web-reviewers` team as a reviewer to every P
 PRs opened from a fork cannot access repository secrets, so CI and the preview deployment do not run
 automatically. The process requires a maintainer to explicitly approve each step:
 
-1. A maintainer approves the CI run on the [Actions tab](https://github.com/Telefonica/mistica-web/actions) so
-   the standard checks execute against the fork's code.
+1. A maintainer approves the CI run on the PR so the standard checks execute against the fork's code.
 2. A maintainer reviews the PR and adds the `safe-to-deploy` label. This captures the exact commit SHA at that
    moment and triggers the deployment workflow.
-3. A maintainer must then open the triggered workflow run on the
-   [Actions tab](https://github.com/Telefonica/mistica-web/actions) and click **Review deployments** to
-   approve it. This approval gate is required before any secrets are exposed.
+3. The triggered workflow post a link to the workflow run, which a manitainer has to approve. This approval
+   gate is required before any secrets are exposed.
 4. Once approved, the preview is deployed against the pinned commit SHA. The deployment URL is printed in the
    workflow run logs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thank you for your interest in Mística. You can contribute to this project in s
 <!-- TOC depthFrom:2 -->
 
 - [Pull Requests](#pull-requests)
+  - [Fork PRs — preview deployment](#fork-prs--preview-deployment)
 - [Bug reports](#bug-reports)
 - [Feature requests (no UI/UX changes)](#feature-requests-no-uiux-changes)
 - [Documentation and help requests](#documentation-and-help-requests)
@@ -53,6 +54,23 @@ Concise summary of the problem and fix, ending with `Ref: <ISSUE-ID>`;
 ### Reviewers
 
 Always add the `@Telefonica/mistica-web-reviewers` team as a reviewer to every PR.
+
+### Fork PRs — preview deployment
+
+PRs opened from a fork cannot access repository secrets, so the preview deployment does not run automatically.
+The process requires a maintainer to explicitly mark the code as safe to deploy:
+
+1. A maintainer reviews the PR and adds the `safe-to-deploy` label. This captures the exact commit SHA at that
+   moment and triggers the deployment workflow.
+2. A maintainer must then open the triggered workflow run on the
+   [Actions tab](https://github.com/Telefonica/mistica-web/actions) and click **Review deployments** to
+   approve it. This approval gate is required before any secrets are exposed.
+3. Once approved, the preview is deployed against the pinned commit SHA. The deployment URL is printed in the
+   workflow run logs.
+
+> [!IMPORTANT] If you push new commits to your branch after the `safe-to-deploy` label is added, the
+> deployment will fail with a SHA mismatch. A maintainer must remove the label and add it again to re-trigger
+> the deployment for the new commits.
 
 ## Bug reports
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,15 +57,17 @@ Always add the `@Telefonica/mistica-web-reviewers` team as a reviewer to every P
 
 ### Fork PRs — preview deployment
 
-PRs opened from a fork cannot access repository secrets, so the preview deployment does not run automatically.
-The process requires a maintainer to explicitly mark the code as safe to deploy:
+PRs opened from a fork cannot access repository secrets, so CI and the preview deployment do not run
+automatically. The process requires a maintainer to explicitly approve each step:
 
-1. A maintainer reviews the PR and adds the `safe-to-deploy` label. This captures the exact commit SHA at that
+1. A maintainer approves the CI run on the [Actions tab](https://github.com/Telefonica/mistica-web/actions) so
+   the standard checks execute against the fork's code.
+2. A maintainer reviews the PR and adds the `safe-to-deploy` label. This captures the exact commit SHA at that
    moment and triggers the deployment workflow.
-2. A maintainer must then open the triggered workflow run on the
+3. A maintainer must then open the triggered workflow run on the
    [Actions tab](https://github.com/Telefonica/mistica-web/actions) and click **Review deployments** to
    approve it. This approval gate is required before any secrets are exposed.
-3. Once approved, the preview is deployed against the pinned commit SHA. The deployment URL is printed in the
+4. Once approved, the preview is deployed against the pinned commit SHA. The deployment URL is printed in the
    workflow run logs.
 
 > [!IMPORTANT] If you push new commits to your branch after the `safe-to-deploy` label is added, the


### PR DESCRIPTION
## Summary

- `label-trigger-deploy` now passes `pr.head.sha` as `commitSha` when dispatching the fork preview workflow, capturing the reviewed commit at the exact moment the `safe-to-deploy` label fires.
- `deploy-fork-pr-preview` accepts `commitSha` as a required input, validates its format, and compares it against the live `pr.head.sha` before any checkout — failing immediately if the fork branch has been updated since the label was added.
- Checkout now uses the pinned commit SHA directly instead of the dynamic merge ref.

## Test plan

- [ ] Add `safe-to-deploy` to a fork PR and verify the workflow dispatches and deploys successfully.
- [ ] Push a new commit to the fork branch immediately after adding the label; verify the workflow fails with the SHA mismatch error before reaching the checkout step.
- [ ] Attempt to dispatch the workflow manually with an invalid `commitSha` (e.g. wrong length); verify it fails validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)