### PR TITLE
chore(Chore): simplify fork PR contribution flow

### DIFF
--- a/.github/actions/audit-accessibility/action.yml
+++ b/.github/actions/audit-accessibility/action.yml
@@ -11,6 +11,10 @@ inputs:
     azure-account-key:
         description: 'Azure Account Key'
         required: true
+    fork-pr:
+        description: 'Set to true when running on a fork PR to skip Azure upload and PR comment'
+        required: false
+        default: 'false'
 runs:
     using: 'node16'
     main: 'main.js'

--- a/.github/actions/audit-accessibility/main.js
+++ b/.github/actions/audit-accessibility/main.js
@@ -147,6 +147,40 @@ const generateReportForConsole = async (results) => {
 /**
  * @param {Array<[story: string, skin: string, results: import('axe-core').AxeResults]>} results
  */
+const generateReportForStepSummary = (results) => {
+    const problemsCount = results.reduce((acc, [, , result]) => acc + result.violations.length, 0);
+
+    const lines = ['## Accessibility report', ''];
+
+    if (problemsCount > 0) {
+        lines.push(`❌ **${problemsCount}** problems detected`, '');
+        for (const [story, skin, result] of results) {
+            if (result.violations.length) {
+                lines.push(`### ${story} [${skin}] (${result.violations.length} violations)`);
+                for (const violation of result.violations) {
+                    lines.push(
+                        `- **${violation.id}**: ${violation.description} (${violation.nodes.length} node(s))`
+                    );
+                }
+                lines.push('');
+            }
+        }
+        core.setFailed('Accessibility problems detected');
+    } else {
+        lines.push('✔️ No issues found');
+    }
+
+    lines.push('', 'ℹ️ You can run this locally by executing `yarn audit-accessibility`.');
+
+    const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+    if (summaryPath) {
+        fs.appendFileSync(summaryPath, lines.join('\n') + '\n');
+    }
+};
+
+/**
+ * @param {Array<[story: string, skin: string, results: import('axe-core').AxeResults]>} results
+ */
 const generateReportForGithub = async (results) => {
     const files = await writeReportsToDisk(results);
 
@@ -297,7 +331,12 @@ const main = async () => {
     console.log('total time:', Date.now() - t, 'ms');
 
     if (process.env.CI) {
-        await generateReportForGithub(results);
+        const isForkPr = core.getInput('fork-pr') === 'true';
+        if (isForkPr) {
+            generateReportForStepSummary(results);
+        } else {
+            await generateReportForGithub(results);
+        }
     } else {
         await generateReportForConsole(results);
     }

--- a/.github/actions/upload-failed-screenshots/action.yml
+++ b/.github/actions/upload-failed-screenshots/action.yml
@@ -12,6 +12,10 @@ inputs:
     azure-account-key:
         description: 'Azure Account Key'
         required: true
+    fork-pr:
+        description: 'Set to true when running on a fork PR to skip Azure upload and PR comment'
+        required: false
+        default: 'false'
     glob:
         description: 'Glob to match diff image files'
         required: false

--- a/.github/actions/upload-failed-screenshots/main.js
+++ b/.github/actions/upload-failed-screenshots/main.js
@@ -6,10 +6,41 @@ const {basename} = require('path');
 const glob = require('glob');
 const {commentPullRequest} = require('../utils/github');
 
+const fs = require('fs');
+
+/** @param {string} content */
+const writeStepSummary = (content) => {
+    const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+    if (summaryPath) {
+        fs.appendFileSync(summaryPath, content + '\n');
+    }
+};
+
 const main = async () => {
-    const filenames = glob.sync(core.getInput('glob') || process.env.INPUT_GLOB);
+    const filenames = glob.sync(core.getInput('glob') || process.env.INPUT_GLOB || '');
+    const isForkPr = core.getInput('fork-pr') === 'true';
 
     core.info('Upload failed screenshot test diffs');
+
+    if (isForkPr) {
+        if (filenames.length) {
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const lines = [
+                '## ❌ Screenshot test failures',
+                '',
+                'Screenshot diffs are available as artifacts in this workflow run.',
+                `[Download from the Actions run](${runUrl})`,
+                '',
+                '### Failed diffs',
+                ...filenames.map((f) => `- \`${basename(f)}\``),
+            ];
+            writeStepSummary(lines.join('\n'));
+            core.setFailed('Screenshot test failures detected');
+        } else {
+            writeStepSummary('## ✔️ All screenshot tests passing');
+        }
+        return;
+    }
 
     const uploads = [];
 

--- a/.github/workflows/audit-a11y.yml
+++ b/.github/workflows/audit-a11y.yml
@@ -31,3 +31,4 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   azure-account-name: ${{ secrets.AZURE_ACCOUNT_NAME }}
                   azure-account-key: ${{ secrets.AZURE_ACCOUNT_KEY }}
+                  fork-pr: ${{ github.event.pull_request.head.repo.full_name != github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   azure-account-name: ${{ secrets.AZURE_ACCOUNT_NAME }}
                   azure-account-key: ${{ secrets.AZURE_ACCOUNT_KEY }}
+                  fork-pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
     validate-pr-title:
         # This job validates the PR title against the conventional commit format. Needed for semantic-release to generate release notes.

--- a/.github/workflows/deploy-fork-pr-preview.yml
+++ b/.github/workflows/deploy-fork-pr-preview.yml
@@ -75,12 +75,12 @@ jobs:
                   script: |
                       const prNumber = Number('${{ steps.pr.outputs.pr_number }}');
                       const { owner, repo } = context.repo;
-                      const marker = '<!-- vercel-preview-url -->';
+                      const marker = '<!-- fork-deploy-status -->';
 
                       const succeeded = '${{ steps.deploy.outcome }}' === 'success';
                       const body = succeeded
-                        ? `${marker}\n### Vercel Preview\n\n| Name | Link |\n| --- | --- |\n| Preview | ${{ steps.deploy.outputs.preview-url }} |`
-                        : `${marker}\n### Vercel Preview\n\n> [!CAUTION]\n> Deployment failed. [Check the workflow run](https://github.com/${owner}/${repo}/actions/runs/${{ github.run_id }}) for details.`;
+                        ? `${marker}\n### Preview deployment\n\n**Step 3/3** — Deployed! ✅\n\n| Name | Link |\n| --- | --- |\n| Preview | ${{ steps.deploy.outputs.preview-url }} |`
+                        : `${marker}\n### Preview deployment\n\n**Step 3/3** — Deployment failed. ❌\n\n> [!CAUTION]\n> [Check the workflow run](https://github.com/${owner}/${repo}/actions/runs/${{ github.run_id }}) for details.`;
 
                       const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber });
                       const existing = comments.find(c => c.body && c.body.includes(marker));

--- a/.github/workflows/fork-deploy-reminder.yml
+++ b/.github/workflows/fork-deploy-reminder.yml
@@ -20,12 +20,12 @@ jobs:
                   script: |
                       const { owner, repo } = context.repo;
                       const prNumber = context.issue.number;
-                      const marker = '<!-- fork-deploy-reminder -->';
+                      const marker = '<!-- fork-deploy-status -->';
                       const body = [
                         marker,
                         '### Preview deployment',
                         '',
-                        'This PR comes from a fork and cannot be deployed automatically.',
+                        '**Step 1/3** — This PR comes from a fork and cannot be deployed automatically.',
                         'To trigger a preview deployment, a maintainer must add the `safe-to-deploy` label.',
                         '',
                         '> [!NOTE]',

--- a/.github/workflows/label-trigger-deploy.yml
+++ b/.github/workflows/label-trigger-deploy.yml
@@ -51,15 +51,25 @@ jobs:
 
                       core.info(`Dispatched deploy-fork-pr-preview for PR #${prNumber}`);
 
-                      // post an audit comment on the PR
+                      // Update the existing fork-deploy-status comment to step 2/3
                       const runUrl = dispatch?.html_url ?? `https://github.com/${owner}/${repo}/actions`;
+                      const marker = '<!-- fork-deploy-status -->';
                       const commentBody = [
-                        '### 🚀 Fork preview deploy triggered',
+                        marker,
+                        '### Preview deployment',
                         '',
-                        `The \`${TARGET_LABEL}\` label was added and the fork preview workflow has been dispatched.`,
+                        `**Step 2/3** — \`${TARGET_LABEL}\` label added, fork preview workflow dispatched.`,
                         '',
                         '> [!IMPORTANT]',
                         '> A reviewer must **approve the workflow run** before it can access deploy secrets.',
                         `> [Open the run and click **Review deployments** to approve it.](${runUrl})`,
                       ].join('\n');
-                      await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body: commentBody });
+
+                      const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber });
+                      const existing = comments.find(c => c.body && c.body.includes(marker));
+
+                      if (existing) {
+                        await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: commentBody });
+                      } else {
+                        await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body: commentBody });
+                      }


### PR DESCRIPTION
## Summary

- Consolidate the three fork-deploy PR comments into a single comment updated progressively (step 1/3 → step 2/3 → step 3/3), reducing noise on fork PRs.
- Fix `audit-a11y` and `build-upload-failed-screenshots` CI jobs that were failing on fork PRs because `pull_request` events from forks do not expose secrets and provide a read-only `GITHUB_TOKEN`. Both jobs now detect fork PRs via `github.event.pull_request.head.repo.full_name != github.repository` and write their results to the GitHub Step Summary instead of uploading to Azure or posting a PR comment.

## Test plan

- [ ] Open a fork PR and verify exactly one comment appears with the step 1/3 message.
- [ ] Add the `safe-to-deploy` label and verify the same comment is updated to step 2/3 (no new comment created).
- [ ] Approve the workflow run and verify the same comment is updated to step 3/3 with the Vercel preview URL.
- [ ] On a fork PR with failing screenshot/accessibility tests, confirm the CI jobs do not fail and the job summary shows the relevant failure details.
- [ ] On a non-fork PR, confirm existing behaviour is unchanged: Azure upload works, PR comments appear.

Ref: #1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)