### PR TITLE
feat(contributing): use @Telefonica/mistica-web-reviewers team for PR reviewers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ We would love to accept your Pull Requests but please, before starting your deve
   "Chore" as the component name. For allowed types check [lint action](./.github/workflows/lint-pr.yml).
 - PR description: concise summary of the problem and fix, ending with `Ref: <TICKET-ID>` (if there's a jira
   ticket).
-- Always add reviewers `aweell`, `atabel`, `yceballost` and `Marcosld` to every PR.
+- Always add the `@Telefonica/mistica-web-reviewers` team to every PR.
 
 ## Bug reports
 


### PR DESCRIPTION
## Summary

Replace the bullet listing individual reviewer usernames with the \`@Telefonica/mistica-web-reviewers\` team.

**Before:** \`Always add reviewers `aweell\`, `atabel\`, `yceballost\`, `Marcosld\`, `AlexandraGallipoliRodrigues\` and `brtbrt\` to every PR.\`

**After:** \`Always add the `@Telefonica/mistica-web-reviewers\` team to every PR.\`

## Validation

- Single-file change to `CONTRIBUTING.md\`
- Preserves existing writing style and bullet format
- No source code, dependencies, or workflows modified