### PR TITLE
feat(Skin): updates vivo-evo skin to use new responsiveLayoutMargin values

### DIFF
--- a/src/skins/vivo-evolution.tsx
+++ b/src/skins/vivo-evolution.tsx
@@ -840,7 +840,7 @@ export const getVivoEvolutionSkin: GetKnownSkin = () => {
                 right: {mobile: 16, desktop: 40},
             },
             boxedDefaultPadding: {left: {mobile: 16, desktop: 24}, right: {mobile: 16, desktop: 24}},
-            responsiveLayoutMargin: {mobile: 8, desktop: 48},
+            responsiveLayoutMargin: {mobile: 16, desktop: 48},
         },
     };
     return skin;


### PR DESCRIPTION
This PR updates the vivo-evolution skin responsiveLayoutMargin to use 16px, updated with the branch used for https://github.com/Telefonica/mistica-design/pull/2828.